### PR TITLE
feat: add app-level exceptionHandler for error reporting integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,27 @@ $app = App::build(
 
 Custom handlers are PSR-15 middleware implementing `MiddlewareInterface`. They are responsible for their own logging, error formatting, and configuration.
 
+### App-Level Exception Handler
+
+In addition to the route-level `throwableHandler`, you can provide an `exceptionHandler` closure to customize error handling at the application level (e.g. for errors that occur outside the middleware stack). This is useful for integrating error reporting services like Sentry, Bugsnag, or Datadog:
+
+```php
+$app = App::build(
+    controllers: ['App\Controllers'],
+    throwableHandler: new CustomErrorHandler(),        // route-level errors (PSR-15)
+    exceptionHandler: function (\Throwable $e): ?array {  // app-level safety net
+        \Sentry\captureException($e);
+        return null; // use default error response
+    },
+);
+```
+
+The `exceptionHandler` closure receives the `\Throwable` and can:
+- Return an `array` (`['statusCode' => ..., 'body' => ..., 'headers' => ...]`) to fully control the response
+- Return `null` to use the default 500 error response (logging is suppressed to avoid duplicates)
+
+When no `exceptionHandler` is provided, the existing default behavior is preserved.
+
 ### JSON Responses
 
 Use `JsonResponse` for convenience:

--- a/src/App.php
+++ b/src/App.php
@@ -31,7 +31,8 @@ class App
         private readonly RequestHandlerInterface $router,
         private readonly ContainerInterface $container,
         private readonly ?LoggerInterface $logger = null,
-        private readonly bool $debugMode = false
+        private readonly bool $debugMode = false,
+        private readonly ?\Closure $exceptionHandler = null,
     ) {
     }
 
@@ -46,7 +47,8 @@ class App
         ?bool $debugMode = false,
         ?array $middlewares = [],
         ?bool $includeRoleCheck = true,
-        ?MiddlewareInterface $throwableHandler = null
+        ?MiddlewareInterface $throwableHandler = null,
+        ?\Closure $exceptionHandler = null
     ): self {
         if (empty($controllers)) {
             throw new \InvalidArgumentException('No controllers provided');
@@ -117,7 +119,7 @@ class App
             }
         }
 
-        return new self($router, $container, $logger, (bool) $debugMode);
+        return new self($router, $container, $logger, (bool) $debugMode, $exceptionHandler);
     }
 
     public function getRouter(): RequestHandlerInterface
@@ -167,10 +169,17 @@ class App
                 'headers' => $headers,
             ];
         } catch (\Throwable $e) {
-            if ($this->logger) {
-                $this->logger->error($e->getMessage(), [
-                    'trace' => $e->getTraceAsString(),
-                ]);
+            if ($this->exceptionHandler !== null) {
+                $result = ($this->exceptionHandler)($e);
+                if (is_array($result)) {
+                    return $result;
+                }
+            } else {
+                if ($this->logger) {
+                    $this->logger->error($e->getMessage(), [
+                        'trace' => $e->getTraceAsString(),
+                    ]);
+                }
             }
 
             $body = [

--- a/src/App.php
+++ b/src/App.php
@@ -197,7 +197,7 @@ class App
             } else {
                 if ($this->logger) {
                     $this->logger->error($e->getMessage(), [
-                        'trace' => $e->getTraceAsString(),
+                        'exception' => $e,
                     ]);
                 }
             }

--- a/src/App.php
+++ b/src/App.php
@@ -172,8 +172,19 @@ class App
             if ($this->exceptionHandler !== null) {
                 try {
                     $result = ($this->exceptionHandler)($e);
-                    if (is_array($result)) {
+                    if (
+                        is_array($result)
+                        && isset($result['statusCode'], $result['body'], $result['headers'])
+                        && is_int($result['statusCode'])
+                        && is_string($result['body'])
+                        && is_array($result['headers'])
+                    ) {
                         return $result;
+                    }
+                    if (is_array($result) && $this->logger) {
+                        $this->logger->error('Exception handler returned malformed response', [
+                            'exception' => $e,
+                        ]);
                     }
                 } catch (\Throwable $handlerException) {
                     if ($this->logger) {

--- a/src/App.php
+++ b/src/App.php
@@ -178,9 +178,8 @@ class App
                 } catch (\Throwable $handlerException) {
                     if ($this->logger) {
                         $this->logger->error('Exception handler failed', [
-                            'handler_error' => $handlerException->getMessage(),
-                            'original_error' => $e->getMessage(),
-                            'trace' => $handlerException->getTraceAsString(),
+                            'exception' => $handlerException,
+                            'previous_exception' => $e,
                         ]);
                     }
                 }

--- a/src/App.php
+++ b/src/App.php
@@ -170,9 +170,19 @@ class App
             ];
         } catch (\Throwable $e) {
             if ($this->exceptionHandler !== null) {
-                $result = ($this->exceptionHandler)($e);
-                if (is_array($result)) {
-                    return $result;
+                try {
+                    $result = ($this->exceptionHandler)($e);
+                    if (is_array($result)) {
+                        return $result;
+                    }
+                } catch (\Throwable $handlerException) {
+                    if ($this->logger) {
+                        $this->logger->error('Exception handler failed', [
+                            'handler_error' => $handlerException->getMessage(),
+                            'original_error' => $e->getMessage(),
+                            'trace' => $handlerException->getTraceAsString(),
+                        ]);
+                    }
                 }
             } else {
                 if ($this->logger) {

--- a/tests/Integration/AppTest.php
+++ b/tests/Integration/AppTest.php
@@ -375,4 +375,51 @@ class AppTest extends TestCase
         self::assertInstanceOf(\RuntimeException::class, $logs[0]['context']['previous_exception']);
         self::assertSame('Original error', $logs[0]['context']['previous_exception']->getMessage());
     }
+
+    public function testExceptionHandlerReturningMalformedArrayFallsBackToDefault(): void
+    {
+        $logger = new TestLogger();
+        $router = new class() implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+            {
+                throw new \RuntimeException('Some error');
+            }
+        };
+        $app = new App(
+            $router,
+            (new ContainerBuilder())->build(),
+            $logger,
+            false,
+            function (\Throwable $e): array {
+                return [
+                    'wrong' => 'shape',
+                ];
+            }
+        );
+
+        $event = [
+            "http" => [
+                "path" => "/test",
+                "body" => "",
+                "isBase64Encoded" => false,
+                "queryString" => "",
+                "method" => "GET",
+                "headers" => [],
+            ],
+        ];
+        $context = new class() {
+            public string $apiHost = "https://example.com";
+        };
+
+        $response = $app->run($event, $context);
+
+        self::assertSame(500, $response['statusCode']);
+        $body = json_decode($response['body'], true);
+        self::assertSame('Internal Server Error', $body['error']);
+
+        $logs = $logger->getLogs();
+        self::assertCount(1, $logs);
+        self::assertSame('error', $logs[0]['level']);
+        self::assertSame('Exception handler returned malformed response', $logs[0]['message']);
+    }
 }

--- a/tests/Integration/AppTest.php
+++ b/tests/Integration/AppTest.php
@@ -326,4 +326,51 @@ class AppTest extends TestCase
         self::assertInstanceOf(\RuntimeException::class, $captured);
         self::assertSame('Captured exception', $captured->getMessage());
     }
+
+    public function testExceptionHandlerThrowingReturnsDefaultResponseAndLogs(): void
+    {
+        $logger = new TestLogger();
+        $router = new class() implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+            {
+                throw new \RuntimeException('Original error');
+            }
+        };
+        $app = new App(
+            $router,
+            (new ContainerBuilder())->build(),
+            $logger,
+            false,
+            function (\Throwable $e): ?array {
+                throw new \RuntimeException('Handler blew up');
+            }
+        );
+
+        $event = [
+            "http" => [
+                "path" => "/test",
+                "body" => "",
+                "isBase64Encoded" => false,
+                "queryString" => "",
+                "method" => "GET",
+                "headers" => [],
+            ],
+        ];
+        $context = new class() {
+            public string $apiHost = "https://example.com";
+        };
+
+        $response = $app->run($event, $context);
+
+        self::assertSame(500, $response['statusCode']);
+        $body = json_decode($response['body'], true);
+        self::assertSame('Internal Server Error', $body['error']);
+
+        $logs = $logger->getLogs();
+        self::assertCount(1, $logs);
+        self::assertSame('error', $logs[0]['level']);
+        self::assertSame('Exception handler failed', $logs[0]['message']);
+        self::assertSame('Handler blew up', $logs[0]['context']['handler_error']);
+        self::assertSame('Original error', $logs[0]['context']['original_error']);
+    }
 }

--- a/tests/Integration/AppTest.php
+++ b/tests/Integration/AppTest.php
@@ -234,4 +234,96 @@ class AppTest extends TestCase
         self::assertSame('Debug visible error', $body['message']);
         self::assertIsString($body['trace']);
     }
+
+    public function testExceptionHandlerIsCalledAndResponseReturned(): void
+    {
+        $router = new class() implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+            {
+                throw new \RuntimeException('Handled exception');
+            }
+        };
+        $app = new App(
+            $router,
+            (new ContainerBuilder())->build(),
+            null,
+            false,
+            function (\Throwable $e): array {
+                return [
+                    'statusCode' => 503,
+                    'body' => json_encode([
+                        'error' => 'Custom: ' . $e->getMessage(),
+                    ]),
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                    ],
+                ];
+            }
+        );
+
+        $event = [
+            "http" => [
+                "path" => "/test",
+                "body" => "",
+                "isBase64Encoded" => false,
+                "queryString" => "",
+                "method" => "GET",
+                "headers" => [],
+            ],
+        ];
+        $context = new class() {
+            public string $apiHost = "https://example.com";
+        };
+
+        $response = $app->run($event, $context);
+
+        self::assertSame(503, $response['statusCode']);
+        $body = json_decode($response['body'], true);
+        self::assertSame('Custom: Handled exception', $body['error']);
+    }
+
+    public function testExceptionHandlerReturningNullSuppressesLoggingButUsesDefaultResponse(): void
+    {
+        $logger = new TestLogger();
+        $captured = null;
+        $router = new class() implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+            {
+                throw new \RuntimeException('Captured exception');
+            }
+        };
+        $app = new App(
+            $router,
+            (new ContainerBuilder())->build(),
+            $logger,
+            false,
+            function (\Throwable $e) use (&$captured): ?array {
+                $captured = $e;
+                return null;
+            }
+        );
+
+        $event = [
+            "http" => [
+                "path" => "/test",
+                "body" => "",
+                "isBase64Encoded" => false,
+                "queryString" => "",
+                "method" => "GET",
+                "headers" => [],
+            ],
+        ];
+        $context = new class() {
+            public string $apiHost = "https://example.com";
+        };
+
+        $response = $app->run($event, $context);
+
+        self::assertSame(500, $response['statusCode']);
+        $body = json_decode($response['body'], true);
+        self::assertSame('Internal Server Error', $body['error']);
+        self::assertEmpty($logger->getLogs());
+        self::assertInstanceOf(\RuntimeException::class, $captured);
+        self::assertSame('Captured exception', $captured->getMessage());
+    }
 }

--- a/tests/Integration/AppTest.php
+++ b/tests/Integration/AppTest.php
@@ -370,7 +370,9 @@ class AppTest extends TestCase
         self::assertCount(1, $logs);
         self::assertSame('error', $logs[0]['level']);
         self::assertSame('Exception handler failed', $logs[0]['message']);
-        self::assertSame('Handler blew up', $logs[0]['context']['handler_error']);
-        self::assertSame('Original error', $logs[0]['context']['original_error']);
+        self::assertInstanceOf(\RuntimeException::class, $logs[0]['context']['exception']);
+        self::assertSame('Handler blew up', $logs[0]['context']['exception']->getMessage());
+        self::assertInstanceOf(\RuntimeException::class, $logs[0]['context']['previous_exception']);
+        self::assertSame('Original error', $logs[0]['context']['previous_exception']->getMessage());
     }
 }

--- a/tests/Integration/AppTest.php
+++ b/tests/Integration/AppTest.php
@@ -193,7 +193,7 @@ class AppTest extends TestCase
         self::assertCount(1, $logs);
         self::assertSame('error', $logs[0]['level']);
         self::assertSame('Test exception', $logs[0]['message']);
-        self::assertIsString($logs[0]['context']['trace']);
+        self::assertInstanceOf(\RuntimeException::class, $logs[0]['context']['exception']);
     }
 
     public function testItExposesErrorDetailInDebugMode(): void


### PR DESCRIPTION
Add optional Closure exceptionHandler parameter to App constructor and build() to customize error handling at the application level. This prevents duplicate logging when used alongside the route-level throwableHandler, enabling clean integration with services like Sentry, Bugsnag, or Datadog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an application-level exception handler option to customize error responses (can return a full HTTP response array or defer to the default 500).

* **Documentation**
  * README updated with usage and behavior details, including fallback behavior and logging interactions.

* **Tests**
  * Added integration tests for handler-returned responses, handler returning null (fallback + suppressed duplicate logging), and handler failures (fallback + error log).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->