### PR TITLE
fix: stack traces missing for routed exceptions (PSR-3 exception key in strategy)

### DIFF
--- a/src/Strategy/DolphinAppStrategy.php
+++ b/src/Strategy/DolphinAppStrategy.php
@@ -65,11 +65,10 @@ class DolphinAppStrategy extends JsonStrategy
                         $message = $exception->getMessage();
                         if ($this->logger) {
                             $this->logger->warning(
-                                $message,
+                                $exception->getMessage(),
                                 [
-                                    'message' => $exception->getMessage(),
+                                    'exception' => $exception,
                                     'request' => (string) $request->getBody(),
-                                    'trace' => $exception->getTrace(),
                                 ]
                             );
                         }
@@ -78,11 +77,10 @@ class DolphinAppStrategy extends JsonStrategy
                         $message = 'Internal Server Error';
                         if ($this->logger) {
                             $this->logger->critical(
-                                $message,
+                                $exception->getMessage(),
                                 [
-                                    'message' => $exception->getMessage(),
+                                    'exception' => $exception,
                                     'request' => (string) $request->getBody(),
-                                    'trace' => $exception->getTrace(),
                                 ]
                             );
                         }
@@ -230,11 +228,10 @@ class DolphinAppStrategy extends JsonStrategy
                 $message = $this->exception->getMessage();
                 if ($this->logger) {
                     $this->logger->warning(
-                        $message,
+                        $this->exception->getMessage(),
                         [
-                            'message' => $this->exception->getMessage(),
+                            'exception' => $this->exception,
                             'request' => (string) $request->getBody(),
-                            'trace' => $this->exception->getTrace(),
                         ]
                     );
                 }


### PR DESCRIPTION
## Summary

- Mirror the PSR-3 logging cleanup from 3.2.0 (commits `3a5b73b`, `0fb3e36`) into `DolphinAppStrategy.php`. Those commits fixed `App.php` only; the strategy's middleware path was missed.
- The throwable handler and the HTTP-exception response middleware now place the throwable under the PSR-3 `'exception'` context key, which is what Sentry's Monolog handler reads to call `captureException()` and produce a stack trace.
- Previously, every routed exception logged the literal string `'Internal Server Error'` with the throwable buried under custom `'message'`/`'trace'` keys, so the Sentry/Monolog handler fell back to `captureMessage()` and emitted trace-less events.
- HTTP response body is unchanged — `'Internal Server Error'` is still the reason phrase. Only the log/Sentry payload changes.

## Why this was missed in 3.2.0

PR #75 (`feature/custom-throwable-handler`) introduced the PSR-3 fix but only edited `src/App.php`. `App::run()` exceptions surfaced correctly in Sentry afterwards, but exceptions caught inside League\Route's middleware chain (i.e. anything thrown from a routed handler) hit the strategy's catch block and stayed trace-less. This PR finishes the job.

## Test plan

- [ ] `make coveralls` — existing tests assert response shapes only, not log context, so should pass unchanged
- [ ] Manual: trigger a 500 in a downstream service (e.g. payments) and confirm Sentry shows a stack-traced event grouped by exception class instead of a trace-less "Internal Server Error" message event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved exception logging to better capture and structure exception information in log records for enhanced debugging insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->