### PR TITLE
feat: RequiresPermission attribute + RoleInterface/PermissionInterface markers + RequiresRoles enum support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,9 +13,14 @@ src/
 ├── App.php                          # Application bootstrapper and entry point
 ├── Attributes/
 │   ├── Route.php                    # #[Route] attribute for declaring HTTP routes
-│   └── RequiresRoles.php           # #[RequiresRoles] attribute for RBAC
+│   ├── RequiresRoles.php           # #[RequiresRoles] attribute for RBAC
+│   └── RequiresPermission.php      # #[RequiresPermission] attribute (repeatable, ANY-of)
 ├── Authentication/
 │   └── AuthenticatedUserInterface.php  # Contract for authenticated users
+├── Authorization/
+│   ├── RoleInterface.php            # Marker for user-family enums
+│   ├── PermissionInterface.php      # Marker for permission enums
+│   └── AuthorizationServiceInterface.php  # App-provided authorisation policy
 ├── Request/
 │   └── Method.php                   # HTTP method enum (GET, POST, PUT, etc.)
 ├── Response/
@@ -91,6 +96,8 @@ Extends League Route's `JsonStrategy` to add:
 
 - **Role-based access control** — Reads `#[RequiresRoles]` attributes from the matched controller class. If roles are required, it looks for an `AuthenticatedUserInterface` on the request's `user` attribute (typically set by middleware). Throws `401 Unauthorized` if no user is present, or `403 Forbidden` if the user lacks the required roles.
 
+- **Permission-based access control** — Reads repeatable `#[RequiresPermission]` attributes (after role enforcement) and delegates the decision to the app-bound `AuthorizationServiceInterface`, resolved from the container by `App::build()`. Multiple attributes mean ANY-of: the route passes if any one permission is allowed. Throws `403 Forbidden` when all are denied, and a `RuntimeException` when the attribute is present but no service is bound — misconfiguration fails loudly.
+
 - **Automatic parameter injection** — Inspects the controller's `__invoke` parameters via reflection and injects:
   - `ServerRequestInterface` — the PSR-7 request
   - `array` — route variables
@@ -117,7 +124,9 @@ Class name resolution for array element types uses PHP-Parser to read `use` stat
 
 - **`#[Route(Method $method, string $path)]`** — Declares the HTTP method and path a controller handles. Applied at the class level.
 
-- **`#[RequiresRoles(array $roles)]`** — Declares which roles are required to access a controller. The strategy checks the user's roles (via `AuthenticatedUserInterface`) against these before invoking the controller.
+- **`#[RequiresRoles(array $roles)]`** — Declares which roles are required to access a controller. Accepts role-name strings and/or `RoleInterface` enum cases (normalised to strings on construction). The strategy checks the user's roles (via `AuthenticatedUserInterface`) against these before invoking the controller.
+
+- **`#[RequiresPermission(RoleInterface $userKind, PermissionInterface $permission)]`** — Declares that accessing a controller requires a permission, checked through the app's `AuthorizationServiceInterface`. Repeatable with ANY-of semantics.
 
 ### Authentication
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -27,6 +27,7 @@ src/
 │   └── JsonResponse.php             # Convenience class for JSON responses
 └── Strategy/
     ├── DolphinAppStrategy.php       # Custom routing strategy (DI, DTO mapping, RBAC)
+    ├── AccessControlEnforcer.php    # RequiresRoles/RequiresPermission enforcement
     ├── DtoMapper.php                # Reflection-based JSON-to-DTO mapper
     └── Exception/
         ├── DtoMapperException.php
@@ -94,9 +95,9 @@ The central class with two responsibilities:
 
 Extends League Route's `JsonStrategy` to add:
 
-- **Role-based access control** — Reads `#[RequiresRoles]` attributes from the matched controller class. If roles are required, it looks for an `AuthenticatedUserInterface` on the request's `user` attribute (typically set by middleware). Throws `401 Unauthorized` if no user is present, or `403 Forbidden` if the user lacks the required roles.
+- **Role-based access control** (via `AccessControlEnforcer`) — Reads `#[RequiresRoles]` attributes from the matched controller class. If roles are required, it looks for an `AuthenticatedUserInterface` on the request's `user` attribute (typically set by middleware). Throws `401 Unauthorized` if no user is present, or `403 Forbidden` if the user lacks the required roles.
 
-- **Permission-based access control** — Reads repeatable `#[RequiresPermission]` attributes (after role enforcement) and delegates the decision to the app-bound `AuthorizationServiceInterface`, resolved from the container by `App::build()`. Multiple attributes mean ANY-of: the route passes if any one permission is allowed. Throws `403 Forbidden` when all are denied, and a `RuntimeException` when the attribute is present but no service is bound — misconfiguration fails loudly.
+- **Permission-based access control** (via `AccessControlEnforcer`) — Reads repeatable `#[RequiresPermission]` attributes (after role enforcement) and delegates the decision to the app-bound `AuthorizationServiceInterface`, resolved from the container by `App::build()`. Multiple attributes mean ANY-of: the route passes if any one permission is allowed. Throws `403 Forbidden` when all are denied, and a `RuntimeException` when the attribute is present but no service is bound — misconfiguration fails loudly.
 
 - **Automatic parameter injection** — Inspects the controller's `__invoke` parameters via reflection and injects:
   - `ServerRequestInterface` — the PSR-7 request

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Dolphin is a lightweight PHP framework (PHP >= 8.2) for running serverless functions on DigitalOcean. It builds on League Route and PHP-DI, adding attribute-based routing, automatic JSON-to-DTO mapping, and role-based access control. Published on Packagist as `strictlyphp/dolphpin`. See ARCHITECTURE.md for full internals.
+
+## Commands
+
+All Make targets build and run inside the Docker image defined in `Dockerfile` (no local PHP needed):
+
+```bash
+make install         # Install dependencies (removes vendor/ and composer.lock first)
+make analyze         # PHPStan static analysis, level 6, on src and tests
+make style           # Check coding style (ECS: PSR-12 + spaces/array/docblock/strict sets)
+make style-fix       # Auto-fix coding style
+make check-coverage  # Run all tests + verify coverage of files changed vs origin/main is >= 86%
+make coveralls       # Run tests with coverage and upload to Coveralls
+```
+
+There is no plain `make test` target — `make check-coverage` is how CI runs the suite. To run tests directly (or a single test), run PHPUnit inside the Docker container:
+
+```bash
+docker build -t strictlyphp82/dolphin .
+docker run --user=$(id -u):$(id -g) --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp strictlyphp82/dolphin \
+  ./vendor/bin/phpunit tests/                                         # all tests
+docker run --user=$(id -u):$(id -g) --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp strictlyphp82/dolphin \
+  ./vendor/bin/phpunit tests/Unit/Strategy/DtoMapperTest.php          # one file
+docker run --user=$(id -u):$(id -g) --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp strictlyphp82/dolphin \
+  ./vendor/bin/phpunit --filter testMethodName tests/                 # one test
+```
+
+CI (`.github/workflows/pull_request.yml`) runs `make style`, `make analyze`, and `make check-coverage` on every PR — all three must pass.
+
+## Architecture
+
+Small source tree (`src/`), with the interesting logic concentrated in three places:
+
+- **`App.php`** — `App::build()` is the static factory: creates the PHP-DI container, sets up Monolog, scans the given controller namespaces with ClassFinder, reads `#[Route]` attributes from discovered classes, and registers routes on a League Router using the custom strategy. `App::run()` converts a DigitalOcean function event/context pair into a PSR-7 request, dispatches it, and returns `['statusCode', 'body', 'headers']`.
+
+- **`Strategy/DolphinAppStrategy.php`** — extends League Route's `JsonStrategy`. On each matched route it: checks `#[RequiresRoles]` against the `user` request attribute (`AuthenticatedUserInterface`, set by user middleware; 401 if absent, 403 if roles missing), resolves controller `__invoke` parameters via reflection (PSR-7 request, route vars array, or any class type mapped from the JSON body), and converts exceptions into structured JSON error responses (full details when debug mode is on).
+
+- **`Strategy/DtoMapper.php`** — reflection-based JSON-to-object mapper. Handles scalars, value objects (single-constructor-arg classes), nested DTOs (recursive), backed enums (`::tryFrom()`), nullable params, and typed arrays whose element type comes from `@param array<Type>` docblocks. Array element class names are resolved by parsing the DTO source file's `use` statements with PHP-Parser (cached per class).
+
+Tests are split into `tests/Unit` and `tests/Integration` (full `App::build()`/`run()` round-trips), with shared controllers/DTOs/middleware in `tests/Fixtures`.
+
+## Release process
+
+Releases are branch-driven (current branch pattern: `release/x.y.z`):
+
+1. `./build/create-release.sh <version>` — creates `release/<version>`, regenerates `changelog.txt` from git log since the last tag, bumps `version` in `composer.json`, runs the full check suite, commits as `chore: prepare release <version>`, and pushes.
+2. Merging that branch to `main` triggers `tag-and-release-on-merge-v1.yml`, which extracts the version from the merge commit message, tags it, and creates a GitHub release using `changelog.txt` as the body.
+
+Do not hand-edit `changelog.txt` or the `version` field in `composer.json` outside this flow.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,70 @@ class AuthMiddleware implements MiddlewareInterface
 
 The `AuthenticatedUserInterface` requires `getId(): string` and `getRoles(): array`.
 
+`#[RequiresRoles]` also accepts enum cases implementing `RoleInterface` (alongside plain strings) — they are normalised to their backing string values:
+
+```php
+#[RequiresRoles([UserRole::ADMIN, 'SUPPORT'])]
+class UpdateSettingsController { /* ... */ }
+```
+
+### Permission-Based Access Control
+
+For finer-grained authorisation, protect controllers with `#[RequiresPermission]`. Dolphin owns the vocabulary and the attribute-driven enforcement; the authorisation policy itself lives in your app.
+
+1. Define enums for your user families and permissions using the marker interfaces:
+
+```php
+use StrictlyPHP\Dolphin\Authorization\PermissionInterface;
+use StrictlyPHP\Dolphin\Authorization\RoleInterface;
+
+enum UserKind: string implements RoleInterface
+{
+    case RECRUITER = 'RECRUITER';
+    case CLIENT = 'CLIENT';
+}
+
+enum RecruiterPermission: string implements PermissionInterface
+{
+    case CREATE_VACANCY = 'CREATE_VACANCY';
+    case DELETE_VACANCY = 'DELETE_VACANCY';
+}
+```
+
+2. Implement `AuthorizationServiceInterface` with your app's policy (matrix lookups, bypass rules for back-office roles, etc.) and bind it in the container:
+
+```php
+use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
+
+$app = App::build(
+    controllers: ['App\Controllers'],
+    containerDefinitions: [
+        AuthorizationServiceInterface::class => fn() => new MyAuthorizationService(),
+    ],
+    middlewares: [AuthMiddleware::class], // sets the 'user' request attribute
+);
+```
+
+3. Decorate route handlers:
+
+```php
+#[Route(Method::POST, '/vacancies')]
+#[RequiresPermission(UserKind::RECRUITER, RecruiterPermission::CREATE_VACANCY)]
+class CreateVacancyController { /* ... */ }
+```
+
+The framework calls `isAllowed($user, $userKind, $permission)` before invoking the controller and returns `403 Forbidden` when it returns `false` (or `401 Unauthorized` when no user is on the request).
+
+The attribute is repeatable with ANY-of (logical OR) semantics — the user needs at least one of the listed permissions:
+
+```php
+#[RequiresPermission(UserKind::RECRUITER, RecruiterPermission::DELETE_VACANCY)]
+#[RequiresPermission(UserKind::CLIENT, ClientPermission::DELETE_VACANCY)]
+class DeleteVacancyController { /* ... */ }
+```
+
+If a controller declares `#[RequiresPermission]` but no `AuthorizationServiceInterface` is bound, the framework throws a `RuntimeException` — a misconfigured app fails loudly rather than silently allowing or denying.
+
 ### Dependency Injection
 
 Dolphin uses [PHP-DI](https://php-di.org/) for dependency injection. Pass container definitions to `App::build()`:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For a detailed look at the internals, see [ARCHITECTURE.md](ARCHITECTURE.md).
 ## Installation
 
 ```bash
-composer require strictlyphp/dolphin:^3.0
+composer require strictlyphp/dolphpin:^3.0
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ use StrictlyPHP\Dolphin\Authorization\RoleInterface;
 
 enum UserKind: string implements RoleInterface
 {
-    case RECRUITER = 'RECRUITER';
-    case CLIENT = 'CLIENT';
+    case USER = 'USER';
+    case ADMIN = 'ADMIN';
 }
 
-enum RecruiterPermission: string implements PermissionInterface
+enum AdminPermission: string implements PermissionInterface
 {
-    case CREATE_VACANCY = 'CREATE_VACANCY';
-    case DELETE_VACANCY = 'DELETE_VACANCY';
+    case CREATE_REPORT = 'CREATE_REPORT';
+    case DELETE_REPORT = 'DELETE_REPORT';
 }
 ```
 
@@ -191,9 +191,9 @@ $app = App::build(
 3. Decorate route handlers:
 
 ```php
-#[Route(Method::POST, '/vacancies')]
-#[RequiresPermission(UserKind::RECRUITER, RecruiterPermission::CREATE_VACANCY)]
-class CreateVacancyController { /* ... */ }
+#[Route(Method::POST, '/reports')]
+#[RequiresPermission(UserKind::ADMIN, AdminPermission::CREATE_REPORT)]
+class CreateReportController { /* ... */ }
 ```
 
 The framework calls `isAllowed($user, $userKind, $permission)` before invoking the controller and returns `403 Forbidden` when it returns `false` (or `401 Unauthorized` when no user is on the request).
@@ -201,9 +201,9 @@ The framework calls `isAllowed($user, $userKind, $permission)` before invoking t
 The attribute is repeatable with ANY-of (logical OR) semantics — the user needs at least one of the listed permissions:
 
 ```php
-#[RequiresPermission(UserKind::RECRUITER, RecruiterPermission::DELETE_VACANCY)]
-#[RequiresPermission(UserKind::CLIENT, ClientPermission::DELETE_VACANCY)]
-class DeleteVacancyController { /* ... */ }
+#[RequiresPermission(UserKind::ADMIN, AdminPermission::DELETE_REPORT)]
+#[RequiresPermission(UserKind::USER, UserPermission::DELETE_REPORT)]
+class DeleteReportController { /* ... */ }
 ```
 
 If a controller declares `#[RequiresPermission]` but no `AuthorizationServiceInterface` is bound, the framework throws a `RuntimeException` — a misconfigured app fails loudly rather than silently allowing or denying.

--- a/ecs.php
+++ b/ecs.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
+use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
+use PhpCsFixer\Fixer\Strict\StrictParamFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
@@ -13,12 +16,19 @@ return static function (ECSConfig $ecsConfig): void {
         'syntax' => 'short',
     ]);
 
+    // the rules previously provided by SetList::STRICT, which newer ECS
+    // versions reject as a deprecated set
+    $ecsConfig->rules([
+        StrictComparisonFixer::class,
+        StrictParamFixer::class,
+        DeclareStrictTypesFixer::class,
+    ]);
+
     // run and fix, one by one
     $ecsConfig->sets([
         SetList::SPACES,
         SetList::ARRAY,
         SetList::DOCBLOCK,
-        SetList::STRICT,
         SetList::PSR_12
     ]);
 };

--- a/src/App.php
+++ b/src/App.php
@@ -21,6 +21,7 @@ use Slim\Psr7\Factory\UriFactory;
 use Slim\Psr7\Headers;
 use Slim\Psr7\Request;
 use StrictlyPHP\Dolphin\Attributes\Route;
+use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
 use StrictlyPHP\Dolphin\Request\Method;
 use StrictlyPHP\Dolphin\Strategy\DolphinAppStrategy;
 use StrictlyPHP\Dolphin\Strategy\DtoMapper;
@@ -73,13 +74,18 @@ class App
             $container->set(LoggerInterface::class, $logger);
         }
 
+        $authorizationService = $container->has(AuthorizationServiceInterface::class)
+            ? $container->get(AuthorizationServiceInterface::class)
+            : null;
+
         $strategy = new DolphinAppStrategy(
             dtoMapper: new DtoMapper(),
             responseFactory: new ResponseFactory(),
             logger: $logger,
             debugMode: $debugMode,
             includeRoleCheck: $includeRoleCheck,
-            throwableHandler: $throwableHandler
+            throwableHandler: $throwableHandler,
+            authorizationService: $authorizationService
         );
         $strategy->setContainer($container);
         $router = new Router();

--- a/src/Attributes/RequiresPermission.php
+++ b/src/Attributes/RequiresPermission.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Dolphin\Attributes;
+
+use Attribute;
+use StrictlyPHP\Dolphin\Authorization\PermissionInterface;
+use StrictlyPHP\Dolphin\Authorization\RoleInterface;
+
+/**
+ * Declares that a route handler requires a permission, resolved through the
+ * app-bound AuthorizationServiceInterface.
+ *
+ * Repeatable: multiple instances on one class mean ANY-of (logical OR) —
+ * the user needs at least one of the listed permissions to be allowed.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class RequiresPermission
+{
+    public function __construct(
+        public readonly RoleInterface $userKind,
+        public readonly PermissionInterface $permission,
+    ) {
+    }
+}

--- a/src/Attributes/RequiresRoles.php
+++ b/src/Attributes/RequiresRoles.php
@@ -5,15 +5,24 @@ declare(strict_types=1);
 namespace StrictlyPHP\Dolphin\Attributes;
 
 use Attribute;
+use StrictlyPHP\Dolphin\Authorization\RoleInterface;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class RequiresRoles
 {
     /**
-     * @param string[] $roles
+     * @var string[]
      */
-    public function __construct(
-        public array $roles
-    ) {
+    public readonly array $roles;
+
+    /**
+     * @param array<int, string|RoleInterface> $roles
+     */
+    public function __construct(array $roles)
+    {
+        $this->roles = array_map(
+            static fn (string|RoleInterface $role): string => $role instanceof RoleInterface ? (string) $role->value : $role,
+            $roles,
+        );
     }
 }

--- a/src/Authorization/AuthorizationServiceInterface.php
+++ b/src/Authorization/AuthorizationServiceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Dolphin\Authorization;
+
+use StrictlyPHP\Dolphin\Authentication\AuthenticatedUserInterface;
+
+/**
+ * App-provided authorisation policy. Returns true if $user (with whatever
+ * runtime role/state they have) should be allowed to perform $permission on
+ * a route declared for $userKind. Implementations encapsulate per-app rules:
+ * matrix lookups, bypass policies for back-office roles, etc.
+ */
+interface AuthorizationServiceInterface
+{
+    public function isAllowed(
+        AuthenticatedUserInterface $user,
+        RoleInterface $userKind,
+        PermissionInterface $permission,
+    ): bool;
+}

--- a/src/Authorization/PermissionInterface.php
+++ b/src/Authorization/PermissionInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Dolphin\Authorization;
+
+/**
+ * Marker interface for enums whose cases represent individual permissions.
+ * Each user family typically has its own permission enum.
+ */
+interface PermissionInterface extends \BackedEnum
+{
+}

--- a/src/Authorization/RoleInterface.php
+++ b/src/Authorization/RoleInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Dolphin\Authorization;
+
+/**
+ * Marker interface for enums whose cases identify a family of users
+ * (recruiters, clients, admins). Consumers implement this on their own
+ * backed enum; the app's AuthorizationServiceInterface knows how to
+ * resolve the caller's concrete role within that family.
+ */
+interface RoleInterface extends \BackedEnum
+{
+}

--- a/src/Authorization/RoleInterface.php
+++ b/src/Authorization/RoleInterface.php
@@ -6,7 +6,7 @@ namespace StrictlyPHP\Dolphin\Authorization;
 
 /**
  * Marker interface for enums whose cases identify a family of users
- * (recruiters, clients, admins). Consumers implement this on their own
+ * (users, admins). Consumers implement this on their own
  * backed enum; the app's AuthorizationServiceInterface knows how to
  * resolve the caller's concrete role within that family.
  */

--- a/src/Strategy/AccessControlEnforcer.php
+++ b/src/Strategy/AccessControlEnforcer.php
@@ -27,16 +27,16 @@ class AccessControlEnforcer
 
     /**
      * Runs role enforcement first, then permission enforcement.
-     * Returns the request with the 'required_roles' attribute set.
+     * Returns the request with the 'required_roles' and 'required_permissions'
+     * attributes set.
      */
     public function enforce(
         ReflectionMethod|ReflectionFunction $ref,
         ServerRequestInterface $request
     ): ServerRequestInterface {
         $request = $this->enforceRoles($ref, $request);
-        $this->enforcePermissions($ref, $request);
 
-        return $request;
+        return $this->enforcePermissions($ref, $request);
     }
 
     private function enforceRoles(
@@ -72,15 +72,20 @@ class AccessControlEnforcer
     private function enforcePermissions(
         ReflectionMethod|ReflectionFunction $ref,
         ServerRequestInterface $request
-    ): void {
-        if (! $ref instanceof ReflectionMethod) {
-            // Function handlers have no declaring class to carry attributes
-            return;
-        }
+    ): ServerRequestInterface {
+        $requiredPermissions = [];
 
-        $permissionAttrs = $ref->getDeclaringClass()->getAttributes(RequiresPermission::class);
-        if (empty($permissionAttrs)) {
-            return;
+        // Class-level attributes (function handlers have no declaring class)
+        if ($ref instanceof ReflectionMethod) {
+            $permissionAttrs = $ref->getDeclaringClass()->getAttributes(RequiresPermission::class);
+            foreach ($permissionAttrs as $permissionAttr) {
+                $requiredPermissions[] = $permissionAttr->newInstance();
+            }
+        }
+        $request = $request->withAttribute('required_permissions', $requiredPermissions);
+
+        if (empty($requiredPermissions)) {
+            return $request;
         }
 
         if ($this->authorizationService === null) {
@@ -94,8 +99,7 @@ class AccessControlEnforcer
 
         // ANY-of semantics: the user needs at least one of the listed permissions
         $allowed = false;
-        foreach ($permissionAttrs as $permissionAttr) {
-            $requiresPermission = $permissionAttr->newInstance();
+        foreach ($requiredPermissions as $requiresPermission) {
             if ($this->authorizationService->isAllowed(
                 $user,
                 $requiresPermission->userKind,
@@ -111,6 +115,8 @@ class AccessControlEnforcer
                 'User does not have permission to access this resource'
             );
         }
+
+        return $request;
     }
 
     private function getAuthenticatedUser(ServerRequestInterface $request): AuthenticatedUserInterface

--- a/src/Strategy/AccessControlEnforcer.php
+++ b/src/Strategy/AccessControlEnforcer.php
@@ -45,11 +45,13 @@ class AccessControlEnforcer
     ): ServerRequestInterface {
         $requiredRoles = [];
 
-        // Class-level attributes
-        $classAttrs = $ref->getDeclaringClass()->getAttributes(RequiresRoles::class);
-        if (! empty($classAttrs)) {
-            $instance = $classAttrs[0]->newInstance();
-            $requiredRoles = array_merge($requiredRoles, $instance->roles);
+        // Class-level attributes (function handlers have no declaring class)
+        if ($ref instanceof ReflectionMethod) {
+            $classAttrs = $ref->getDeclaringClass()->getAttributes(RequiresRoles::class);
+            if (! empty($classAttrs)) {
+                $instance = $classAttrs[0]->newInstance();
+                $requiredRoles = array_merge($requiredRoles, $instance->roles);
+            }
         }
         $request = $request->withAttribute('required_roles', $requiredRoles);
 
@@ -71,6 +73,11 @@ class AccessControlEnforcer
         ReflectionMethod|ReflectionFunction $ref,
         ServerRequestInterface $request
     ): void {
+        if (! $ref instanceof ReflectionMethod) {
+            // Function handlers have no declaring class to carry attributes
+            return;
+        }
+
         $permissionAttrs = $ref->getDeclaringClass()->getAttributes(RequiresPermission::class);
         if (empty($permissionAttrs)) {
             return;

--- a/src/Strategy/AccessControlEnforcer.php
+++ b/src/Strategy/AccessControlEnforcer.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Dolphin\Strategy;
+
+use League\Route\Http\Exception\ForbiddenException;
+use League\Route\Http\Exception\UnauthorizedException;
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionFunction;
+use ReflectionMethod;
+use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
+use StrictlyPHP\Dolphin\Attributes\RequiresRoles;
+use StrictlyPHP\Dolphin\Authentication\AuthenticatedUserInterface;
+use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
+
+/**
+ * Enforces #[RequiresRoles] and #[RequiresPermission] attributes declared
+ * on a matched route handler.
+ */
+class AccessControlEnforcer
+{
+    public function __construct(
+        private ?AuthorizationServiceInterface $authorizationService = null
+    ) {
+    }
+
+    /**
+     * Runs role enforcement first, then permission enforcement.
+     * Returns the request with the 'required_roles' attribute set.
+     */
+    public function enforce(
+        ReflectionMethod|ReflectionFunction $ref,
+        ServerRequestInterface $request
+    ): ServerRequestInterface {
+        $request = $this->enforceRoles($ref, $request);
+        $this->enforcePermissions($ref, $request);
+
+        return $request;
+    }
+
+    private function enforceRoles(
+        ReflectionMethod|ReflectionFunction $ref,
+        ServerRequestInterface $request
+    ): ServerRequestInterface {
+        $requiredRoles = [];
+
+        // Class-level attributes
+        $classAttrs = $ref->getDeclaringClass()->getAttributes(RequiresRoles::class);
+        if (! empty($classAttrs)) {
+            $instance = $classAttrs[0]->newInstance();
+            $requiredRoles = array_merge($requiredRoles, $instance->roles);
+        }
+        $request = $request->withAttribute('required_roles', $requiredRoles);
+
+        if (! empty($requiredRoles)) {
+            $user = $this->getAuthenticatedUser($request);
+
+            // Intersect the required roles with the user roles
+            if (empty(array_intersect($user->getRoles(), $requiredRoles))) {
+                throw new ForbiddenException(
+                    'User does not have permission to access this resource'
+                );
+            }
+        }
+
+        return $request;
+    }
+
+    private function enforcePermissions(
+        ReflectionMethod|ReflectionFunction $ref,
+        ServerRequestInterface $request
+    ): void {
+        $permissionAttrs = $ref->getDeclaringClass()->getAttributes(RequiresPermission::class);
+        if (empty($permissionAttrs)) {
+            return;
+        }
+
+        if ($this->authorizationService === null) {
+            throw new \RuntimeException(
+                'Route handler declares #[RequiresPermission] but no AuthorizationServiceInterface is bound. ' .
+                'Inject one into DolphinAppStrategy.'
+            );
+        }
+
+        $user = $this->getAuthenticatedUser($request);
+
+        // ANY-of semantics: the user needs at least one of the listed permissions
+        $allowed = false;
+        foreach ($permissionAttrs as $permissionAttr) {
+            $requiresPermission = $permissionAttr->newInstance();
+            if ($this->authorizationService->isAllowed(
+                $user,
+                $requiresPermission->userKind,
+                $requiresPermission->permission
+            )) {
+                $allowed = true;
+                break;
+            }
+        }
+
+        if (! $allowed) {
+            throw new ForbiddenException(
+                'User does not have permission to access this resource'
+            );
+        }
+    }
+
+    private function getAuthenticatedUser(ServerRequestInterface $request): AuthenticatedUserInterface
+    {
+        // Your auth system sets this earlier in global middleware
+        $user = $request->getAttribute('user');
+
+        if (! $user) {
+            throw new UnauthorizedException(
+                'User is not authenticated'
+            );
+        }
+
+        if (! $user instanceof AuthenticatedUserInterface) {
+            throw new \RuntimeException(
+                sprintf('Authenticated user must implement %s', AuthenticatedUserInterface::class)
+            );
+        }
+
+        return $user;
+    }
+}

--- a/src/Strategy/DolphinAppStrategy.php
+++ b/src/Strategy/DolphinAppStrategy.php
@@ -6,8 +6,6 @@ namespace StrictlyPHP\Dolphin\Strategy;
 
 use League\Route\Http;
 use League\Route\Http\Exception\BadRequestException;
-use League\Route\Http\Exception\ForbiddenException;
-use League\Route\Http\Exception\UnauthorizedException;
 use League\Route\Route;
 use League\Route\Strategy\JsonStrategy;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -19,14 +17,13 @@ use Psr\Log\LoggerInterface;
 use ReflectionFunction;
 use ReflectionMethod;
 use ReflectionNamedType;
-use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
-use StrictlyPHP\Dolphin\Attributes\RequiresRoles;
-use StrictlyPHP\Dolphin\Authentication\AuthenticatedUserInterface;
 use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
 use Throwable;
 
 class DolphinAppStrategy extends JsonStrategy
 {
+    private AccessControlEnforcer $accessControlEnforcer;
+
     public function __construct(
         private DtoMapper $dtoMapper,
         ResponseFactoryInterface $responseFactory,
@@ -35,9 +32,10 @@ class DolphinAppStrategy extends JsonStrategy
         private ?bool $debugMode = false,
         private ?bool $includeRoleCheck = true,
         private ?MiddlewareInterface $throwableHandler = null,
-        private ?AuthorizationServiceInterface $authorizationService = null
+        ?AuthorizationServiceInterface $authorizationService = null
     ) {
         parent::__construct($responseFactory, $jsonFlags);
+        $this->accessControlEnforcer = new AccessControlEnforcer($authorizationService);
     }
 
     public function getThrowableHandler(): MiddlewareInterface
@@ -127,92 +125,7 @@ class DolphinAppStrategy extends JsonStrategy
         }
 
         if ($this->includeRoleCheck) {
-            // ----------------------------------------------
-            // ROLE ATTRIBUTE EXTRACTION
-            // ----------------------------------------------
-            $requiredRoles = [];
-
-            // Class-level attributes
-            $classAttrs = $ref->getDeclaringClass()->getAttributes(RequiresRoles::class);
-            if (! empty($classAttrs)) {
-                $instance = $classAttrs[0]->newInstance();
-                $requiredRoles = array_merge($requiredRoles, $instance->roles);
-            }
-            $request = $request->withAttribute('required_roles', $requiredRoles);
-
-            // ----------------------------------------------
-            // ROLE ENFORCEMENT
-            // ----------------------------------------------
-            if (! empty($requiredRoles)) {
-                // Your auth system sets this earlier in global middleware
-                $user = $request->getAttribute('user');
-
-                if (! $user) {
-                    throw new UnauthorizedException(
-                        'User is not authenticated'
-                    );
-                }
-
-                if (! $user instanceof AuthenticatedUserInterface) {
-                    throw new \RuntimeException(
-                        sprintf('Authenticated user must implement %s', AuthenticatedUserInterface::class)
-                    );
-                }
-
-                // Intersect the required roles with the user roles
-                if (empty(array_intersect($user->getRoles(), $requiredRoles))) {
-                    throw new ForbiddenException(
-                        'User does not have permission to access this resource'
-                    );
-                }
-            }
-
-            // ----------------------------------------------
-            // PERMISSION ENFORCEMENT
-            // ----------------------------------------------
-            $permissionAttrs = $ref->getDeclaringClass()->getAttributes(RequiresPermission::class);
-            if (! empty($permissionAttrs)) {
-                if ($this->authorizationService === null) {
-                    throw new \RuntimeException(
-                        'Route handler declares #[RequiresPermission] but no AuthorizationServiceInterface is bound. ' .
-                        'Inject one into DolphinAppStrategy.'
-                    );
-                }
-
-                $user = $request->getAttribute('user');
-
-                if (! $user) {
-                    throw new UnauthorizedException(
-                        'User is not authenticated'
-                    );
-                }
-
-                if (! $user instanceof AuthenticatedUserInterface) {
-                    throw new \RuntimeException(
-                        sprintf('Authenticated user must implement %s', AuthenticatedUserInterface::class)
-                    );
-                }
-
-                // ANY-of semantics: the user needs at least one of the listed permissions
-                $allowed = false;
-                foreach ($permissionAttrs as $permissionAttr) {
-                    $requiresPermission = $permissionAttr->newInstance();
-                    if ($this->authorizationService->isAllowed(
-                        $user,
-                        $requiresPermission->userKind,
-                        $requiresPermission->permission
-                    )) {
-                        $allowed = true;
-                        break;
-                    }
-                }
-
-                if (! $allowed) {
-                    throw new ForbiddenException(
-                        'User does not have permission to access this resource'
-                    );
-                }
-            }
+            $request = $this->accessControlEnforcer->enforce($ref, $request);
         }
 
         $parameters = $ref->getParameters();

--- a/src/Strategy/DolphinAppStrategy.php
+++ b/src/Strategy/DolphinAppStrategy.php
@@ -19,8 +19,10 @@ use Psr\Log\LoggerInterface;
 use ReflectionFunction;
 use ReflectionMethod;
 use ReflectionNamedType;
+use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
 use StrictlyPHP\Dolphin\Attributes\RequiresRoles;
 use StrictlyPHP\Dolphin\Authentication\AuthenticatedUserInterface;
+use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
 use Throwable;
 
 class DolphinAppStrategy extends JsonStrategy
@@ -32,7 +34,8 @@ class DolphinAppStrategy extends JsonStrategy
         ?int $jsonFlags = 0,
         private ?bool $debugMode = false,
         private ?bool $includeRoleCheck = true,
-        private ?MiddlewareInterface $throwableHandler = null
+        private ?MiddlewareInterface $throwableHandler = null,
+        private ?AuthorizationServiceInterface $authorizationService = null
     ) {
         parent::__construct($responseFactory, $jsonFlags);
     }
@@ -158,6 +161,53 @@ class DolphinAppStrategy extends JsonStrategy
 
                 // Intersect the required roles with the user roles
                 if (empty(array_intersect($user->getRoles(), $requiredRoles))) {
+                    throw new ForbiddenException(
+                        'User does not have permission to access this resource'
+                    );
+                }
+            }
+
+            // ----------------------------------------------
+            // PERMISSION ENFORCEMENT
+            // ----------------------------------------------
+            $permissionAttrs = $ref->getDeclaringClass()->getAttributes(RequiresPermission::class);
+            if (! empty($permissionAttrs)) {
+                if ($this->authorizationService === null) {
+                    throw new \RuntimeException(
+                        'Route handler declares #[RequiresPermission] but no AuthorizationServiceInterface is bound. ' .
+                        'Inject one into DolphinAppStrategy.'
+                    );
+                }
+
+                $user = $request->getAttribute('user');
+
+                if (! $user) {
+                    throw new UnauthorizedException(
+                        'User is not authenticated'
+                    );
+                }
+
+                if (! $user instanceof AuthenticatedUserInterface) {
+                    throw new \RuntimeException(
+                        sprintf('Authenticated user must implement %s', AuthenticatedUserInterface::class)
+                    );
+                }
+
+                // ANY-of semantics: the user needs at least one of the listed permissions
+                $allowed = false;
+                foreach ($permissionAttrs as $permissionAttr) {
+                    $requiresPermission = $permissionAttr->newInstance();
+                    if ($this->authorizationService->isAllowed(
+                        $user,
+                        $requiresPermission->userKind,
+                        $requiresPermission->permission
+                    )) {
+                        $allowed = true;
+                        break;
+                    }
+                }
+
+                if (! $allowed) {
                     throw new ForbiddenException(
                         'User does not have permission to access this resource'
                     );

--- a/tests/Fixtures/Authorization/TestPermission.php
+++ b/tests/Fixtures/Authorization/TestPermission.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Fixtures\Authorization;
+
+use StrictlyPHP\Dolphin\Authorization\PermissionInterface;
+
+enum TestPermission: string implements PermissionInterface
+{
+    case CREATE_USER = 'CREATE_USER';
+    case DELETE_USER = 'DELETE_USER';
+}

--- a/tests/Fixtures/Authorization/UserKind.php
+++ b/tests/Fixtures/Authorization/UserKind.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Fixtures\Authorization;
+
+use StrictlyPHP\Dolphin\Authorization\RoleInterface;
+
+enum UserKind: string implements RoleInterface
+{
+    case ADMIN = 'ADMIN';
+    case USER = 'USER';
+}

--- a/tests/Fixtures/Authorization/UserType.php
+++ b/tests/Fixtures/Authorization/UserType.php
@@ -6,7 +6,7 @@ namespace StrictlyPHP\Tests\Dolphin\Fixtures\Authorization;
 
 use StrictlyPHP\Dolphin\Authorization\RoleInterface;
 
-enum UserKind: string implements RoleInterface
+enum UserType: string implements RoleInterface
 {
     case ADMIN = 'ADMIN';
     case USER = 'USER';

--- a/tests/Fixtures/TestRequiresAnyPermissionController.php
+++ b/tests/Fixtures/TestRequiresAnyPermissionController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Fixtures;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
+use StrictlyPHP\Dolphin\Attributes\Route;
+use StrictlyPHP\Dolphin\Request\Method;
+use StrictlyPHP\Dolphin\Response\JsonResponse;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserKind;
+
+#[Route(method: Method::POST, path: '/any-permission')]
+#[RequiresPermission(userKind: UserKind::ADMIN, permission: TestPermission::DELETE_USER)]
+#[RequiresPermission(userKind: UserKind::USER, permission: TestPermission::CREATE_USER)]
+class TestRequiresAnyPermissionController
+{
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return new JsonResponse([
+            'response' => 'permission granted',
+        ]);
+    }
+}

--- a/tests/Fixtures/TestRequiresAnyPermissionController.php
+++ b/tests/Fixtures/TestRequiresAnyPermissionController.php
@@ -11,11 +11,11 @@ use StrictlyPHP\Dolphin\Attributes\Route;
 use StrictlyPHP\Dolphin\Request\Method;
 use StrictlyPHP\Dolphin\Response\JsonResponse;
 use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
-use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserKind;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
 
 #[Route(method: Method::POST, path: '/any-permission')]
-#[RequiresPermission(userKind: UserKind::ADMIN, permission: TestPermission::DELETE_USER)]
-#[RequiresPermission(userKind: UserKind::USER, permission: TestPermission::CREATE_USER)]
+#[RequiresPermission(userKind: UserType::ADMIN, permission: TestPermission::DELETE_USER)]
+#[RequiresPermission(userKind: UserType::USER, permission: TestPermission::CREATE_USER)]
 class TestRequiresAnyPermissionController
 {
     public function __invoke(ServerRequestInterface $request): ResponseInterface

--- a/tests/Fixtures/TestRequiresPermissionController.php
+++ b/tests/Fixtures/TestRequiresPermissionController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Fixtures;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
+use StrictlyPHP\Dolphin\Attributes\Route;
+use StrictlyPHP\Dolphin\Request\Method;
+use StrictlyPHP\Dolphin\Response\JsonResponse;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserKind;
+
+#[Route(method: Method::POST, path: '/permission')]
+#[RequiresPermission(userKind: UserKind::ADMIN, permission: TestPermission::CREATE_USER)]
+class TestRequiresPermissionController
+{
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return new JsonResponse([
+            'response' => 'permission granted',
+        ]);
+    }
+}

--- a/tests/Fixtures/TestRequiresPermissionController.php
+++ b/tests/Fixtures/TestRequiresPermissionController.php
@@ -11,10 +11,10 @@ use StrictlyPHP\Dolphin\Attributes\Route;
 use StrictlyPHP\Dolphin\Request\Method;
 use StrictlyPHP\Dolphin\Response\JsonResponse;
 use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
-use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserKind;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
 
 #[Route(method: Method::POST, path: '/permission')]
-#[RequiresPermission(userKind: UserKind::ADMIN, permission: TestPermission::CREATE_USER)]
+#[RequiresPermission(userKind: UserType::ADMIN, permission: TestPermission::CREATE_USER)]
 class TestRequiresPermissionController
 {
     public function __invoke(ServerRequestInterface $request): ResponseInterface

--- a/tests/Integration/AppPermissionTest.php
+++ b/tests/Integration/AppPermissionTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+namespace StrictlyPHP\Tests\Dolphin\Integration;
+
+use PHPUnit\Framework\TestCase;
+use StrictlyPHP\Dolphin\App;
+use StrictlyPHP\Dolphin\Authentication\AuthenticatedUserInterface;
+use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
+use StrictlyPHP\Dolphin\Authorization\PermissionInterface;
+use StrictlyPHP\Dolphin\Authorization\RoleInterface;
+use StrictlyPHP\Tests\Dolphin\Fixtures\InsertAdminUserMiddleware;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestRequiresPermissionController;
+
+class AppPermissionTest extends TestCase
+{
+    public function testItAllowsWhenAuthorizationServiceAllows(): void
+    {
+        $app = App::build(
+            controllers: [
+                TestRequiresPermissionController::class,
+            ],
+            containerDefinitions: [
+                AuthorizationServiceInterface::class => $this->createAuthorizationService(true),
+            ],
+            middlewares: [
+                InsertAdminUserMiddleware::class,
+            ]
+        );
+
+        $response = $app->run($this->createEvent(), $this->createContext());
+
+        $expectedResponse = [
+            'statusCode' => 200,
+            'body' => '{"response":"permission granted"}',
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+        ];
+        self::assertSame($expectedResponse, $response);
+    }
+
+    public function testItReturns403WhenAuthorizationServiceDenies(): void
+    {
+        $app = App::build(
+            controllers: [
+                TestRequiresPermissionController::class,
+            ],
+            containerDefinitions: [
+                AuthorizationServiceInterface::class => $this->createAuthorizationService(false),
+            ],
+            middlewares: [
+                InsertAdminUserMiddleware::class,
+            ]
+        );
+
+        $response = $app->run($this->createEvent(), $this->createContext());
+
+        $expectedResponse = [
+            'statusCode' => 403,
+            'body' => '{"statusCode":403,"reasonPhrase":"User does not have permission to access this resource"}',
+            'headers' => [
+                'content-type' => 'application/json',
+            ],
+        ];
+        self::assertSame($expectedResponse, $response);
+    }
+
+    public function testItReturns500WhenNoAuthorizationServiceIsBound(): void
+    {
+        $app = App::build(
+            controllers: [
+                TestRequiresPermissionController::class,
+            ],
+            middlewares: [
+                InsertAdminUserMiddleware::class,
+            ]
+        );
+
+        $response = $app->run($this->createEvent(), $this->createContext());
+
+        self::assertSame(500, $response['statusCode']);
+        self::assertSame(
+            '{"statusCode":500,"reasonPhrase":"Internal Server Error"}',
+            $response['body']
+        );
+    }
+
+    private function createAuthorizationService(bool $allowed): AuthorizationServiceInterface
+    {
+        return new class($allowed) implements AuthorizationServiceInterface {
+            public function __construct(
+                private bool $allowed
+            ) {
+            }
+
+            public function isAllowed(
+                AuthenticatedUserInterface $user,
+                RoleInterface $userKind,
+                PermissionInterface $permission,
+            ): bool {
+                return $this->allowed;
+            }
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function createEvent(): array
+    {
+        return [
+            'http' => [
+                'path' => '/permission',
+                'body' => '{}',
+                'isBase64Encoded' => false,
+                'queryString' => '',
+                'method' => 'POST',
+                'headers' => [
+                    'accept' => '*/*',
+                    'content-type' => 'application/json',
+                ],
+            ],
+        ];
+    }
+
+    private function createContext(): object
+    {
+        return new class() {
+            public string $apiHost = 'https://faas-lon1-917a94a7.doserverless.co';
+
+            public function getRemainingTimeInMillis(): int
+            {
+                return 1000;
+            }
+        };
+    }
+}

--- a/tests/Unit/Attributes/RequiresPermissionTest.php
+++ b/tests/Unit/Attributes/RequiresPermissionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Unit\Attributes;
+
+use PHPUnit\Framework\TestCase;
+use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserKind;
+
+class RequiresPermissionTest extends TestCase
+{
+    public function testRequiresPermissionAttribute(): void
+    {
+        $attribute = new RequiresPermission(
+            UserKind::ADMIN,
+            TestPermission::CREATE_USER
+        );
+
+        $this->assertSame(UserKind::ADMIN, $attribute->userKind);
+        $this->assertSame(TestPermission::CREATE_USER, $attribute->permission);
+    }
+}

--- a/tests/Unit/Attributes/RequiresPermissionTest.php
+++ b/tests/Unit/Attributes/RequiresPermissionTest.php
@@ -7,18 +7,18 @@ namespace StrictlyPHP\Tests\Dolphin\Unit\Attributes;
 use PHPUnit\Framework\TestCase;
 use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
 use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
-use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserKind;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
 
 class RequiresPermissionTest extends TestCase
 {
     public function testRequiresPermissionAttribute(): void
     {
         $attribute = new RequiresPermission(
-            UserKind::ADMIN,
+            UserType::ADMIN,
             TestPermission::CREATE_USER
         );
 
-        $this->assertSame(UserKind::ADMIN, $attribute->userKind);
+        $this->assertSame(UserType::ADMIN, $attribute->userKind);
         $this->assertSame(TestPermission::CREATE_USER, $attribute->permission);
     }
 }

--- a/tests/Unit/Attributes/RequiresRolesTest.php
+++ b/tests/Unit/Attributes/RequiresRolesTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Unit\Attributes;
+
+use PHPUnit\Framework\TestCase;
+use StrictlyPHP\Dolphin\Attributes\RequiresRoles;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserKind;
+
+class RequiresRolesTest extends TestCase
+{
+    public function testItAcceptsStrings(): void
+    {
+        $attribute = new RequiresRoles(['ADMIN', 'USER']);
+
+        $this->assertSame(['ADMIN', 'USER'], $attribute->roles);
+    }
+
+    public function testItNormalisesRoleInterfaceEnumCasesToStrings(): void
+    {
+        $attribute = new RequiresRoles([UserKind::ADMIN, UserKind::USER]);
+
+        $this->assertSame(['ADMIN', 'USER'], $attribute->roles);
+    }
+
+    public function testItAcceptsMixedStringsAndEnumCases(): void
+    {
+        $attribute = new RequiresRoles(['SUPPORT', UserKind::ADMIN]);
+
+        $this->assertSame(['SUPPORT', 'ADMIN'], $attribute->roles);
+    }
+}

--- a/tests/Unit/Attributes/RequiresRolesTest.php
+++ b/tests/Unit/Attributes/RequiresRolesTest.php
@@ -6,7 +6,7 @@ namespace StrictlyPHP\Tests\Dolphin\Unit\Attributes;
 
 use PHPUnit\Framework\TestCase;
 use StrictlyPHP\Dolphin\Attributes\RequiresRoles;
-use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserKind;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
 
 class RequiresRolesTest extends TestCase
 {
@@ -19,14 +19,14 @@ class RequiresRolesTest extends TestCase
 
     public function testItNormalisesRoleInterfaceEnumCasesToStrings(): void
     {
-        $attribute = new RequiresRoles([UserKind::ADMIN, UserKind::USER]);
+        $attribute = new RequiresRoles([UserType::ADMIN, UserType::USER]);
 
         $this->assertSame(['ADMIN', 'USER'], $attribute->roles);
     }
 
     public function testItAcceptsMixedStringsAndEnumCases(): void
     {
-        $attribute = new RequiresRoles(['SUPPORT', UserKind::ADMIN]);
+        $attribute = new RequiresRoles(['SUPPORT', UserType::ADMIN]);
 
         $this->assertSame(['SUPPORT', 'ADMIN'], $attribute->roles);
     }

--- a/tests/Unit/Strategy/AccessControlEnforcerTest.php
+++ b/tests/Unit/Strategy/AccessControlEnforcerTest.php
@@ -6,8 +6,16 @@ namespace StrictlyPHP\Tests\Dolphin\Unit\Strategy;
 
 use PHPUnit\Framework\TestCase;
 use ReflectionFunction;
+use ReflectionMethod;
 use Slim\Psr7\Factory\ServerRequestFactory;
+use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
+use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
 use StrictlyPHP\Dolphin\Strategy\AccessControlEnforcer;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestRequiresAnyPermissionController;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestRequiresPermissionController;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestUserAdmin;
 
 class AccessControlEnforcerTest extends TestCase
 {
@@ -20,5 +28,63 @@ class AccessControlEnforcerTest extends TestCase
         $result = $enforcer->enforce($ref, $request);
 
         $this->assertSame([], $result->getAttribute('required_roles'));
+        $this->assertSame([], $result->getAttribute('required_permissions'));
+    }
+
+    public function testItSetsRequiredPermissionsAttributeOnTheRequest(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturn(true);
+
+        $enforcer = new AccessControlEnforcer($authorizationService);
+        $ref = new ReflectionMethod(TestRequiresPermissionController::class, '__invoke');
+        $request = (new ServerRequestFactory())->createServerRequest('POST', '/permission')
+            ->withAttribute('user', new TestUserAdmin());
+
+        $result = $enforcer->enforce($ref, $request);
+
+        /** @var array<int, RequiresPermission> $requiredPermissions */
+        $requiredPermissions = $result->getAttribute('required_permissions');
+        $this->assertCount(1, $requiredPermissions);
+        $this->assertInstanceOf(RequiresPermission::class, $requiredPermissions[0]);
+        $this->assertSame(UserType::ADMIN, $requiredPermissions[0]->userKind);
+        $this->assertSame(TestPermission::CREATE_USER, $requiredPermissions[0]->permission);
+    }
+
+    public function testItSetsAllRepeatedPermissionsOnTheRequest(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturn(true);
+
+        $enforcer = new AccessControlEnforcer($authorizationService);
+        $ref = new ReflectionMethod(TestRequiresAnyPermissionController::class, '__invoke');
+        $request = (new ServerRequestFactory())->createServerRequest('POST', '/any-permission')
+            ->withAttribute('user', new TestUserAdmin());
+
+        $result = $enforcer->enforce($ref, $request);
+
+        /** @var array<int, RequiresPermission> $requiredPermissions */
+        $requiredPermissions = $result->getAttribute('required_permissions');
+        $this->assertCount(2, $requiredPermissions);
+        $this->assertSame(TestPermission::DELETE_USER, $requiredPermissions[0]->permission);
+        $this->assertSame(TestPermission::CREATE_USER, $requiredPermissions[1]->permission);
+    }
+
+    public function testHandlersWithoutPermissionAttributesGetEmptyRequiredPermissions(): void
+    {
+        $controller = new class() {
+            public function __invoke(): string
+            {
+                return 'ok';
+            }
+        };
+
+        $enforcer = new AccessControlEnforcer();
+        $ref = new ReflectionMethod($controller, '__invoke');
+        $request = (new ServerRequestFactory())->createServerRequest('GET', '/plain');
+
+        $result = $enforcer->enforce($ref, $request);
+
+        $this->assertSame([], $result->getAttribute('required_permissions'));
     }
 }

--- a/tests/Unit/Strategy/AccessControlEnforcerTest.php
+++ b/tests/Unit/Strategy/AccessControlEnforcerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Unit\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use StrictlyPHP\Dolphin\Strategy\AccessControlEnforcer;
+
+class AccessControlEnforcerTest extends TestCase
+{
+    public function testFunctionHandlersPassThroughWithoutClassAttributeChecks(): void
+    {
+        $enforcer = new AccessControlEnforcer();
+        $ref = new ReflectionFunction(static fn (): string => 'ok');
+        $request = (new ServerRequestFactory())->createServerRequest('GET', '/function-handler');
+
+        $result = $enforcer->enforce($ref, $request);
+
+        $this->assertSame([], $result->getAttribute('required_roles'));
+    }
+}

--- a/tests/Unit/Strategy/DolphinAppStrategyTest.php
+++ b/tests/Unit/Strategy/DolphinAppStrategyTest.php
@@ -4,11 +4,26 @@ declare(strict_types=1);
 
 namespace StrictlyPHP\Tests\Dolphin\Unit\Strategy;
 
+use League\Route\Http\Exception\ForbiddenException;
+use League\Route\Http\Exception\UnauthorizedException;
+use League\Route\Route;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Slim\Psr7\Factory\ResponseFactory;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use StrictlyPHP\Dolphin\Authentication\AuthenticatedUserInterface;
+use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
+use StrictlyPHP\Dolphin\Authorization\PermissionInterface;
+use StrictlyPHP\Dolphin\Authorization\RoleInterface;
+use StrictlyPHP\Dolphin\Response\JsonResponse;
 use StrictlyPHP\Dolphin\Strategy\DolphinAppStrategy;
 use StrictlyPHP\Dolphin\Strategy\DtoMapper;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestRequiresAnyPermissionController;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestRequiresPermissionController;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestUserAdmin;
 
 class DolphinAppStrategyTest extends TestCase
 {
@@ -36,5 +51,138 @@ class DolphinAppStrategyTest extends TestCase
 
         $this->assertInstanceOf(MiddlewareInterface::class, $handler);
         $this->assertNotSame($handler, $strategy->getThrowableHandler());
+    }
+
+    public function testRequiresPermissionAllowsWhenAuthorizationServiceAllows(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturn(true);
+
+        $strategy = $this->createStrategy($authorizationService);
+        $route = new Route('POST', '/permission', new TestRequiresPermissionController());
+
+        $response = $strategy->invokeRouteCallable($route, $this->createAuthenticatedRequest());
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('{"response":"permission granted"}', (string) $response->getBody());
+    }
+
+    public function testRequiresPermissionThrows403WhenAuthorizationServiceDenies(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturn(false);
+
+        $strategy = $this->createStrategy($authorizationService);
+        $route = new Route('POST', '/permission', new TestRequiresPermissionController());
+
+        $this->expectException(ForbiddenException::class);
+        $strategy->invokeRouteCallable($route, $this->createAuthenticatedRequest());
+    }
+
+    public function testRepeatedRequiresPermissionAllowsWhenAnyPermissionAllows(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturnCallback(
+            static fn (
+                AuthenticatedUserInterface $user,
+                RoleInterface $userKind,
+                PermissionInterface $permission
+            ): bool => $permission === TestPermission::CREATE_USER
+        );
+
+        $strategy = $this->createStrategy($authorizationService);
+        // Declares DELETE_USER (denied) and CREATE_USER (allowed) — ANY-of passes
+        $route = new Route('POST', '/any-permission', new TestRequiresAnyPermissionController());
+
+        $response = $strategy->invokeRouteCallable($route, $this->createAuthenticatedRequest());
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRepeatedRequiresPermissionThrows403WhenAllPermissionsDeny(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturn(false);
+
+        $strategy = $this->createStrategy($authorizationService);
+        $route = new Route('POST', '/any-permission', new TestRequiresAnyPermissionController());
+
+        $this->expectException(ForbiddenException::class);
+        $strategy->invokeRouteCallable($route, $this->createAuthenticatedRequest());
+    }
+
+    public function testRequiresPermissionThrowsRuntimeExceptionWhenNoAuthorizationServiceBound(): void
+    {
+        $strategy = $this->createStrategy(null);
+        $route = new Route('POST', '/permission', new TestRequiresPermissionController());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('no AuthorizationServiceInterface is bound');
+        $strategy->invokeRouteCallable($route, $this->createAuthenticatedRequest());
+    }
+
+    public function testRequiresPermissionThrows401WhenNoUserOnRequest(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturn(true);
+
+        $strategy = $this->createStrategy($authorizationService);
+        $route = new Route('POST', '/permission', new TestRequiresPermissionController());
+
+        $this->expectException(UnauthorizedException::class);
+        $strategy->invokeRouteCallable($route, $this->createRequest());
+    }
+
+    public function testRequiresPermissionThrowsRuntimeExceptionWhenUserIsWrongType(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturn(true);
+
+        $strategy = $this->createStrategy($authorizationService);
+        $route = new Route('POST', '/permission', new TestRequiresPermissionController());
+        $request = $this->createRequest()->withAttribute('user', new \stdClass());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(AuthenticatedUserInterface::class);
+        $strategy->invokeRouteCallable($route, $request);
+    }
+
+    public function testStrategyWithoutAuthorizationServiceStillHandlesRoutesWithoutPermissionAttribute(): void
+    {
+        $controller = new class() {
+            public function __invoke(ServerRequestInterface $request): ResponseInterface
+            {
+                return new JsonResponse([
+                    'response' => 'ok',
+                ]);
+            }
+        };
+
+        $strategy = $this->createStrategy(null);
+        $route = new Route('POST', '/plain', $controller);
+
+        $response = $strategy->invokeRouteCallable($route, $this->createRequest());
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('{"response":"ok"}', (string) $response->getBody());
+    }
+
+    private function createStrategy(?AuthorizationServiceInterface $authorizationService): DolphinAppStrategy
+    {
+        return new DolphinAppStrategy(
+            dtoMapper: new DtoMapper(),
+            responseFactory: new ResponseFactory(),
+            authorizationService: $authorizationService
+        );
+    }
+
+    private function createRequest(): ServerRequestInterface
+    {
+        return (new ServerRequestFactory())->createServerRequest('POST', '/permission');
+    }
+
+    private function createAuthenticatedRequest(): ServerRequestInterface
+    {
+        return $this->createRequest()->withAttribute('user', new TestUserAdmin());
     }
 }


### PR DESCRIPTION
## Summary

Extends Dolphin with a generic permission system. Authorisation policy stays out of Dolphin (it lives in the consuming app); Dolphin owns the vocabulary, the extension point, and the attribute-driven enforcement.

### New

- `Authorization\RoleInterface` — marker interface (extends `\BackedEnum`) identifying a family of users (users, admins). Consumers implement it on their own enum.
- `Authorization\PermissionInterface` — marker interface (extends `\BackedEnum`) for enums whose cases represent individual permissions.
- `Authorization\AuthorizationServiceInterface` — the app-provided policy: `isAllowed(AuthenticatedUserInterface $user, RoleInterface $userKind, PermissionInterface $permission): bool`. Implementations encapsulate per-app rules (matrix lookups, bypass policies for back-office roles, etc.). No default implementation ships with Dolphin.
- `#[RequiresPermission(userKind, permission)]` — repeatable class-level attribute. Multiple instances mean **ANY-of** (logical OR): the user needs at least one of the listed permissions.

### Changed

- **`DolphinAppStrategy`** — optional `AuthorizationServiceInterface` constructor dependency. Enforcement runs after the existing `RequiresRoles` block and mirrors its error handling (401 when unauthenticated, 403 when denied). If a handler declares `#[RequiresPermission]` but no service is bound, a `RuntimeException` is thrown — a misconfigured app fails loudly rather than silently allowing/denying. Without the binding, behaviour is unchanged for routes that don't use the attribute.
- **`App::build()`** — resolves `AuthorizationServiceInterface` from the container when bound and injects it into the strategy.
- **`RequiresRoles`** — now accepts `RoleInterface` enum cases alongside strings, normalising to strings on construction. Backward compatible: reflection-instantiated attributes are unaffected (single positional `array` parameter, `roles` name preserved).

### Out of scope (intentional)

- Default authorisation policy implementations — they belong in consuming apps.
- Domain-specific guards (e.g. same-company scoping via path params). Dolphin stays generic.

Also adds a `CLAUDE.md` guidance file for Claude Code.

## Test plan

- [x] `make style` — clean
- [x] `make analyze` (PHPStan level 6) — clean
- [x] Full suite: 60 tests / 129 assertions passing
- [x] Changed-line coverage: 100% (gate is 86%)
- New unit tests: `RequiresRoles` with strings / enum cases / mixed; `RequiresPermission` allowed, 403 on deny, ANY-of OR semantics, `RuntimeException` when unbound, 401 without user, strategy without binding still serves unattributed routes
- New integration tests: end-to-end `App::build()` with the service bound via container definitions (allow → 200, deny → 403, unbound → 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission-based access control via `#[RequiresPermission]` attribute with ANY-of semantics.
  * Enhanced role attributes to support enums alongside strings.
  * Introduced authorization service interface for custom permission policies.

* **Documentation**
  * Updated architecture guide with permission enforcement details.
  * Extended README with permission control configuration and usage examples.
  * Added developer project guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
