### PR TITLE
feat: add RequiresRole and AllowsRole attributes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,8 +13,10 @@ src/
 ├── App.php                          # Application bootstrapper and entry point
 ├── Attributes/
 │   ├── Route.php                    # #[Route] attribute for declaring HTTP routes
-│   ├── RequiresRoles.php           # #[RequiresRoles] attribute for RBAC
-│   └── RequiresPermission.php      # #[RequiresPermission] attribute (repeatable, ANY-of)
+│   ├── RequiresRoles.php           # #[RequiresRoles] attribute for RBAC (string[]/enum)
+│   ├── RequiresRole.php            # #[RequiresRole] enum-only, repeatable role gate
+│   ├── RequiresPermission.php      # #[RequiresPermission] attribute (repeatable, ANY-of)
+│   └── AllowsRole.php              # #[AllowsRole] repeatable, additive role bypass
 ├── Authentication/
 │   └── AuthenticatedUserInterface.php  # Contract for authenticated users
 ├── Authorization/
@@ -95,9 +97,11 @@ The central class with two responsibilities:
 
 Extends League Route's `JsonStrategy` to add:
 
-- **Role-based access control** (via `AccessControlEnforcer`) — Reads `#[RequiresRoles]` attributes from the matched controller class. If roles are required, it looks for an `AuthenticatedUserInterface` on the request's `user` attribute (typically set by middleware). Throws `401 Unauthorized` if no user is present, or `403 Forbidden` if the user lacks the required roles.
+- **Role-based access control** (via `AccessControlEnforcer`) — Reads `#[RequiresRoles]` (and the enum-only, repeatable `#[RequiresRole]`) attributes from the matched controller class, combining them into a single OR-list of required roles. If roles are required, it looks for an `AuthenticatedUserInterface` on the request's `user` attribute (typically set by middleware). Throws `401 Unauthorized` if no user is present, or `403 Forbidden` if the user lacks the required roles.
 
 - **Permission-based access control** (via `AccessControlEnforcer`) — Reads repeatable `#[RequiresPermission]` attributes (after role enforcement) and delegates the decision to the app-bound `AuthorizationServiceInterface`, resolved from the container by `App::build()`. Multiple attributes mean ANY-of: the route passes if any one permission is allowed. Throws `403 Forbidden` when all are denied, and a `RuntimeException` when the attribute is present but no service is bound — misconfiguration fails loudly.
+
+- **Additive role bypass** (via `AccessControlEnforcer`) — `#[AllowsRole]` is checked before the gates: a user holding one of the allowed roles passes regardless of the `#[RequiresRole]`/`#[RequiresRoles]` and `#[RequiresPermission]` gates, skipping the permission check (and the `AuthorizationServiceInterface`) entirely. It is purely additive — it never restricts — so a handler carrying only `#[AllowsRole]` declares no gate and is effectively open.
 
 - **Automatic parameter injection** — Inspects the controller's `__invoke` parameters via reflection and injects:
   - `ServerRequestInterface` — the PSR-7 request
@@ -127,7 +131,11 @@ Class name resolution for array element types uses PHP-Parser to read `use` stat
 
 - **`#[RequiresRoles(array $roles)]`** — Declares which roles are required to access a controller. Accepts role-name strings and/or `RoleInterface` enum cases (normalised to strings on construction). The strategy checks the user's roles (via `AuthenticatedUserInterface`) against these before invoking the controller.
 
+- **`#[RequiresRole(RoleInterface $role)]`** — Enum-only, repeatable counterpart to `#[RequiresRoles]`. Each instance contributes one role; instances combine with the `#[RequiresRoles]` list under ANY-of semantics.
+
 - **`#[RequiresPermission(RoleInterface $userKind, PermissionInterface $permission)]`** — Declares that accessing a controller requires a permission, checked through the app's `AuthorizationServiceInterface`. Repeatable with ANY-of semantics.
+
+- **`#[AllowsRole(RoleInterface $role)]`** — Repeatable, additive bypass: a user holding one of these roles is granted access regardless of the controller's role and permission gates. Never restricts on its own.
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ The `AuthenticatedUserInterface` requires `getId(): string` and `getRoles(): arr
 class UpdateSettingsController { /* ... */ }
 ```
 
+`#[RequiresRole]` is an enum-only, repeatable alternative. Each instance contributes one role, and multiple instances combine with ANY-of (logical OR) semantics — equivalent to the array form above but without the brackets:
+
+```php
+#[RequiresRole(UserRole::ADMIN)]
+#[RequiresRole(UserRole::SUPPORT)]   // ADMIN or SUPPORT
+class UpdateSettingsController { /* ... */ }
+```
+
 ### Permission-Based Access Control
 
 For finer-grained authorisation, protect controllers with `#[RequiresPermission]`. Dolphin owns the vocabulary and the attribute-driven enforcement; the authorisation policy itself lives in your app.
@@ -207,6 +215,23 @@ class DeleteReportController { /* ... */ }
 ```
 
 If a controller declares `#[RequiresPermission]` but no `AuthorizationServiceInterface` is bound, the framework throws a `RuntimeException` — a misconfigured app fails loudly rather than silently allowing or denying.
+
+#### Allowing a role through a permission gate
+
+`#[AllowsRole]` widens access: a user holding one of the listed roles passes regardless of the `#[RequiresPermission]` (or `#[RequiresRole]`) gates on the same controller, and the permission check — including the `AuthorizationServiceInterface` call — is skipped for them. Use it to gate a route on a fine-grained permission while letting a back-office role straight through:
+
+```php
+#[Route(Method::POST, '/reports')]
+#[RequiresPermission(UserKind::USER, UserPermission::CREATE_REPORT)]
+#[AllowsRole(UserKind::ADMIN)]
+class CreateReportController { /* ... */ }
+
+// ADMIN                       -> allowed (no permission check)
+// USER with CREATE_REPORT     -> allowed
+// USER without CREATE_REPORT  -> 403
+```
+
+It is repeatable with ANY-of semantics. `#[AllowsRole]` is **purely additive — it grants, it never restricts.** A controller carrying *only* `#[AllowsRole]` declares no gate and is therefore effectively open; to *restrict* access to a role, use `#[RequiresRole]` or `#[RequiresRoles]`.
 
 ### Dependency Injection
 

--- a/src/Attributes/AllowsRole.php
+++ b/src/Attributes/AllowsRole.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Dolphin\Attributes;
+
+use Attribute;
+use StrictlyPHP\Dolphin\Authorization\RoleInterface;
+
+/**
+ * Widens access for a role: a user holding one of the listed roles passes
+ * regardless of the route's #[RequiresRole]/#[RequiresRoles] or
+ * #[RequiresPermission] gates (the permission check — and its
+ * AuthorizationServiceInterface — is skipped entirely for them).
+ *
+ * Repeatable, with ANY-of (logical OR) semantics. Purely additive: it grants,
+ * it never restricts. A route carrying ONLY #[AllowsRole] declares no gate, so
+ * it is effectively open — to *restrict* access to a role, use #[RequiresRole].
+ *
+ * Typical use is alongside #[RequiresPermission], e.g. restrict to a fine-grained
+ * permission but let a back-office role straight through.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class AllowsRole
+{
+    public function __construct(
+        public readonly RoleInterface $role
+    ) {
+    }
+}

--- a/src/Attributes/RequiresRole.php
+++ b/src/Attributes/RequiresRole.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Dolphin\Attributes;
+
+use Attribute;
+use StrictlyPHP\Dolphin\Authorization\RoleInterface;
+
+/**
+ * Declares a role required to access a route handler. The enum-only,
+ * repeatable counterpart to #[RequiresRoles]: each instance contributes one
+ * role, and multiple instances combine with ANY-of (logical OR) semantics —
+ * the user needs at least one of the listed roles.
+ *
+ * Gates access (produces a 403 when unmet). Use #[AllowsRole] to widen access
+ * for additional roles without restricting.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class RequiresRole
+{
+    public function __construct(
+        public readonly RoleInterface $role
+    ) {
+    }
+}

--- a/src/Strategy/AccessControlEnforcer.php
+++ b/src/Strategy/AccessControlEnforcer.php
@@ -9,14 +9,16 @@ use League\Route\Http\Exception\UnauthorizedException;
 use Psr\Http\Message\ServerRequestInterface;
 use ReflectionFunction;
 use ReflectionMethod;
+use StrictlyPHP\Dolphin\Attributes\AllowsRole;
 use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
+use StrictlyPHP\Dolphin\Attributes\RequiresRole;
 use StrictlyPHP\Dolphin\Attributes\RequiresRoles;
 use StrictlyPHP\Dolphin\Authentication\AuthenticatedUserInterface;
 use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
 
 /**
- * Enforces #[RequiresRoles] and #[RequiresPermission] attributes declared
- * on a matched route handler.
+ * Enforces #[RequiresRoles], #[RequiresRole], #[RequiresPermission] and
+ * #[AllowsRole] attributes declared on a matched route handler.
  */
 class AccessControlEnforcer
 {
@@ -26,36 +28,45 @@ class AccessControlEnforcer
     }
 
     /**
-     * Runs role enforcement first, then permission enforcement.
-     * Returns the request with the 'required_roles' and 'required_permissions'
-     * attributes set.
+     * Runs role enforcement first, then permission enforcement. A user holding
+     * an #[AllowsRole] role bypasses both gates. Returns the request with the
+     * 'required_roles' and 'required_permissions' attributes set.
      */
     public function enforce(
         ReflectionMethod|ReflectionFunction $ref,
         ServerRequestInterface $request
     ): ServerRequestInterface {
-        $request = $this->enforceRoles($ref, $request);
+        // #[AllowsRole] is purely additive: a user holding one of the allowed
+        // roles passes regardless of the role/permission gates below.
+        $bypass = $this->hasAllowingRole($ref, $request);
 
-        return $this->enforcePermissions($ref, $request);
+        $request = $this->enforceRoles($ref, $request, $bypass);
+
+        return $this->enforcePermissions($ref, $request, $bypass);
     }
 
     private function enforceRoles(
         ReflectionMethod|ReflectionFunction $ref,
-        ServerRequestInterface $request
+        ServerRequestInterface $request,
+        bool $bypass
     ): ServerRequestInterface {
         $requiredRoles = [];
 
         // Class-level attributes (function handlers have no declaring class)
         if ($ref instanceof ReflectionMethod) {
-            $classAttrs = $ref->getDeclaringClass()->getAttributes(RequiresRoles::class);
-            if (! empty($classAttrs)) {
-                $instance = $classAttrs[0]->newInstance();
-                $requiredRoles = array_merge($requiredRoles, $instance->roles);
+            $class = $ref->getDeclaringClass();
+
+            foreach ($class->getAttributes(RequiresRoles::class) as $rolesAttr) {
+                $requiredRoles = array_merge($requiredRoles, $rolesAttr->newInstance()->roles);
+            }
+
+            foreach ($class->getAttributes(RequiresRole::class) as $roleAttr) {
+                $requiredRoles[] = (string) $roleAttr->newInstance()->role->value;
             }
         }
         $request = $request->withAttribute('required_roles', $requiredRoles);
 
-        if (! empty($requiredRoles)) {
+        if (! empty($requiredRoles) && ! $bypass) {
             $user = $this->getAuthenticatedUser($request);
 
             // Intersect the required roles with the user roles
@@ -71,7 +82,8 @@ class AccessControlEnforcer
 
     private function enforcePermissions(
         ReflectionMethod|ReflectionFunction $ref,
-        ServerRequestInterface $request
+        ServerRequestInterface $request,
+        bool $bypass
     ): ServerRequestInterface {
         $requiredPermissions = [];
 
@@ -84,7 +96,7 @@ class AccessControlEnforcer
         }
         $request = $request->withAttribute('required_permissions', $requiredPermissions);
 
-        if (empty($requiredPermissions)) {
+        if (empty($requiredPermissions) || $bypass) {
             return $request;
         }
 
@@ -117,6 +129,36 @@ class AccessControlEnforcer
         }
 
         return $request;
+    }
+
+    /**
+     * True when the request carries an authenticated user holding one of the
+     * route's #[AllowsRole] roles. Non-throwing: an absent or wrong-typed user
+     * simply yields false, leaving the gates to raise the appropriate error.
+     */
+    private function hasAllowingRole(
+        ReflectionMethod|ReflectionFunction $ref,
+        ServerRequestInterface $request
+    ): bool {
+        if (! $ref instanceof ReflectionMethod) {
+            return false;
+        }
+
+        $allowedRoles = [];
+        foreach ($ref->getDeclaringClass()->getAttributes(AllowsRole::class) as $allowsRoleAttr) {
+            $allowedRoles[] = (string) $allowsRoleAttr->newInstance()->role->value;
+        }
+
+        if (empty($allowedRoles)) {
+            return false;
+        }
+
+        $user = $request->getAttribute('user');
+        if (! $user instanceof AuthenticatedUserInterface) {
+            return false;
+        }
+
+        return ! empty(array_intersect($user->getRoles(), $allowedRoles));
     }
 
     private function getAuthenticatedUser(ServerRequestInterface $request): AuthenticatedUserInterface

--- a/tests/Fixtures/TestAllowsRoleOnlyController.php
+++ b/tests/Fixtures/TestAllowsRoleOnlyController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Fixtures;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use StrictlyPHP\Dolphin\Attributes\AllowsRole;
+use StrictlyPHP\Dolphin\Attributes\Route;
+use StrictlyPHP\Dolphin\Request\Method;
+use StrictlyPHP\Dolphin\Response\JsonResponse;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
+
+#[Route(method: Method::POST, path: '/allows-role-only')]
+#[AllowsRole(UserType::ADMIN)]
+class TestAllowsRoleOnlyController
+{
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return new JsonResponse([
+            'response' => 'open',
+        ]);
+    }
+}

--- a/tests/Fixtures/TestAllowsRoleOverRoleController.php
+++ b/tests/Fixtures/TestAllowsRoleOverRoleController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Fixtures;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use StrictlyPHP\Dolphin\Attributes\AllowsRole;
+use StrictlyPHP\Dolphin\Attributes\RequiresRole;
+use StrictlyPHP\Dolphin\Attributes\Route;
+use StrictlyPHP\Dolphin\Request\Method;
+use StrictlyPHP\Dolphin\Response\JsonResponse;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
+
+#[Route(method: Method::POST, path: '/allows-role-over-role')]
+#[RequiresRole(UserType::USER)]
+#[AllowsRole(UserType::ADMIN)]
+class TestAllowsRoleOverRoleController
+{
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return new JsonResponse([
+            'response' => 'access granted',
+        ]);
+    }
+}

--- a/tests/Fixtures/TestAllowsRolePermissionController.php
+++ b/tests/Fixtures/TestAllowsRolePermissionController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Fixtures;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use StrictlyPHP\Dolphin\Attributes\AllowsRole;
+use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
+use StrictlyPHP\Dolphin\Attributes\Route;
+use StrictlyPHP\Dolphin\Request\Method;
+use StrictlyPHP\Dolphin\Response\JsonResponse;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
+
+#[Route(method: Method::POST, path: '/allows-role-permission')]
+#[RequiresPermission(userKind: UserType::USER, permission: TestPermission::CREATE_USER)]
+#[AllowsRole(UserType::ADMIN)]
+class TestAllowsRolePermissionController
+{
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return new JsonResponse([
+            'response' => 'access granted',
+        ]);
+    }
+}

--- a/tests/Fixtures/TestRequiresSingleRoleController.php
+++ b/tests/Fixtures/TestRequiresSingleRoleController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Fixtures;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use StrictlyPHP\Dolphin\Attributes\RequiresRole;
+use StrictlyPHP\Dolphin\Attributes\Route;
+use StrictlyPHP\Dolphin\Request\Method;
+use StrictlyPHP\Dolphin\Response\JsonResponse;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
+
+#[Route(method: Method::POST, path: '/requires-role')]
+#[RequiresRole(UserType::ADMIN)]
+#[RequiresRole(UserType::USER)]
+class TestRequiresSingleRoleController
+{
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return new JsonResponse([
+            'response' => 'role granted',
+        ]);
+    }
+}

--- a/tests/Unit/Attributes/AllowsRoleTest.php
+++ b/tests/Unit/Attributes/AllowsRoleTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Unit\Attributes;
+
+use PHPUnit\Framework\TestCase;
+use StrictlyPHP\Dolphin\Attributes\AllowsRole;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
+
+class AllowsRoleTest extends TestCase
+{
+    public function testAllowsRoleAttribute(): void
+    {
+        $attribute = new AllowsRole(UserType::ADMIN);
+
+        $this->assertSame(UserType::ADMIN, $attribute->role);
+    }
+}

--- a/tests/Unit/Attributes/RequiresRoleTest.php
+++ b/tests/Unit/Attributes/RequiresRoleTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Unit\Attributes;
+
+use PHPUnit\Framework\TestCase;
+use StrictlyPHP\Dolphin\Attributes\RequiresRole;
+use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
+
+class RequiresRoleTest extends TestCase
+{
+    public function testRequiresRoleAttribute(): void
+    {
+        $attribute = new RequiresRole(UserType::ADMIN);
+
+        $this->assertSame(UserType::ADMIN, $attribute->role);
+    }
+}

--- a/tests/Unit/Strategy/AccessControlEnforcerTest.php
+++ b/tests/Unit/Strategy/AccessControlEnforcerTest.php
@@ -4,18 +4,25 @@ declare(strict_types=1);
 
 namespace StrictlyPHP\Tests\Dolphin\Unit\Strategy;
 
+use League\Route\Http\Exception\ForbiddenException;
 use PHPUnit\Framework\TestCase;
 use ReflectionFunction;
 use ReflectionMethod;
 use Slim\Psr7\Factory\ServerRequestFactory;
 use StrictlyPHP\Dolphin\Attributes\RequiresPermission;
+use StrictlyPHP\Dolphin\Authentication\AuthenticatedUserInterface;
 use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
 use StrictlyPHP\Dolphin\Strategy\AccessControlEnforcer;
 use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
 use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\UserType;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestAllowsRoleOnlyController;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestAllowsRoleOverRoleController;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestAllowsRolePermissionController;
 use StrictlyPHP\Tests\Dolphin\Fixtures\TestRequiresAnyPermissionController;
 use StrictlyPHP\Tests\Dolphin\Fixtures\TestRequiresPermissionController;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestRequiresSingleRoleController;
 use StrictlyPHP\Tests\Dolphin\Fixtures\TestUserAdmin;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestUserRegular;
 
 class AccessControlEnforcerTest extends TestCase
 {
@@ -86,5 +93,150 @@ class AccessControlEnforcerTest extends TestCase
         $result = $enforcer->enforce($ref, $request);
 
         $this->assertSame([], $result->getAttribute('required_permissions'));
+    }
+
+    public function testRequiresRoleAttributesCombineIntoRequiredRoles(): void
+    {
+        $enforcer = new AccessControlEnforcer();
+        $ref = new ReflectionMethod(TestRequiresSingleRoleController::class, '__invoke');
+        $request = $this->requestWithUser('/requires-role', new TestUserAdmin());
+
+        $result = $enforcer->enforce($ref, $request);
+
+        $this->assertSame(['ADMIN', 'USER'], $result->getAttribute('required_roles'));
+    }
+
+    public function testRequiresRoleAllowsUserHoldingOneOfTheRoles(): void
+    {
+        $enforcer = new AccessControlEnforcer();
+        $ref = new ReflectionMethod(TestRequiresSingleRoleController::class, '__invoke');
+        // TestUserRegular holds USER, which is one of the OR-listed roles
+        $request = $this->requestWithUser('/requires-role', new TestUserRegular());
+
+        $result = $enforcer->enforce($ref, $request);
+
+        $this->assertSame(['ADMIN', 'USER'], $result->getAttribute('required_roles'));
+    }
+
+    public function testRequiresRoleThrows403WhenUserHoldsNoneOfTheRoles(): void
+    {
+        $enforcer = new AccessControlEnforcer();
+        $ref = new ReflectionMethod(TestRequiresSingleRoleController::class, '__invoke');
+        $request = $this->requestWithUser('/requires-role', $this->userWithRoles(['GUEST']));
+
+        $this->expectException(ForbiddenException::class);
+        $enforcer->enforce($ref, $request);
+    }
+
+    public function testAllowsRoleBypassesPermissionGateWithoutCallingService(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturn(false);
+
+        $enforcer = new AccessControlEnforcer($authorizationService);
+        $ref = new ReflectionMethod(TestAllowsRolePermissionController::class, '__invoke');
+        // ADMIN is allowed straight through even though the permission is denied
+        $request = $this->requestWithUser('/allows-role-permission', new TestUserAdmin());
+
+        $result = $enforcer->enforce($ref, $request);
+
+        $this->assertCount(1, $result->getAttribute('required_permissions'));
+    }
+
+    public function testAllowsRoleBypassesPermissionGateEvenWithNoServiceBound(): void
+    {
+        $enforcer = new AccessControlEnforcer();
+        $ref = new ReflectionMethod(TestAllowsRolePermissionController::class, '__invoke');
+        $request = $this->requestWithUser('/allows-role-permission', new TestUserAdmin());
+
+        // Would throw RuntimeException without the bypass; ADMIN escapes the gate
+        $result = $enforcer->enforce($ref, $request);
+
+        $this->assertCount(1, $result->getAttribute('required_permissions'));
+    }
+
+    public function testPermissionGateStillEnforcedForUsersWithoutTheAllowedRole(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturn(true);
+
+        $enforcer = new AccessControlEnforcer($authorizationService);
+        $ref = new ReflectionMethod(TestAllowsRolePermissionController::class, '__invoke');
+        // USER lacks the ADMIN bypass, but the permission is granted
+        $request = $this->requestWithUser('/allows-role-permission', new TestUserRegular());
+
+        $result = $enforcer->enforce($ref, $request);
+
+        $this->assertCount(1, $result->getAttribute('required_permissions'));
+    }
+
+    public function testPermissionGateDeniesUserWithoutAllowedRoleOrPermission(): void
+    {
+        $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
+        $authorizationService->method('isAllowed')->willReturn(false);
+
+        $enforcer = new AccessControlEnforcer($authorizationService);
+        $ref = new ReflectionMethod(TestAllowsRolePermissionController::class, '__invoke');
+        $request = $this->requestWithUser('/allows-role-permission', new TestUserRegular());
+
+        $this->expectException(ForbiddenException::class);
+        $enforcer->enforce($ref, $request);
+    }
+
+    public function testAllowsRoleBypassesRoleGate(): void
+    {
+        $enforcer = new AccessControlEnforcer();
+        $ref = new ReflectionMethod(TestAllowsRoleOverRoleController::class, '__invoke');
+        // Route requires USER; ADMIN lacks it but is allowed through
+        $request = $this->requestWithUser('/allows-role-over-role', new TestUserAdmin());
+
+        $result = $enforcer->enforce($ref, $request);
+
+        $this->assertSame(['USER'], $result->getAttribute('required_roles'));
+    }
+
+    public function testAllowsRoleAloneLeavesRouteOpen(): void
+    {
+        $enforcer = new AccessControlEnforcer();
+        $ref = new ReflectionMethod(TestAllowsRoleOnlyController::class, '__invoke');
+        // No user on the request, no gate declared — nothing to enforce
+        $request = (new ServerRequestFactory())->createServerRequest('POST', '/allows-role-only');
+
+        $result = $enforcer->enforce($ref, $request);
+
+        $this->assertSame([], $result->getAttribute('required_roles'));
+        $this->assertSame([], $result->getAttribute('required_permissions'));
+    }
+
+    private function requestWithUser(string $path, AuthenticatedUserInterface $user): \Psr\Http\Message\ServerRequestInterface
+    {
+        return (new ServerRequestFactory())->createServerRequest('POST', $path)
+            ->withAttribute('user', $user);
+    }
+
+    /**
+     * @param array<int, string> $roles
+     */
+    private function userWithRoles(array $roles): AuthenticatedUserInterface
+    {
+        return new class($roles) implements AuthenticatedUserInterface {
+            /**
+             * @param array<int, string> $roles
+             */
+            public function __construct(
+                private array $roles
+            ) {
+            }
+
+            public function getId(): string
+            {
+                return 'test-user';
+            }
+
+            public function getRoles(): array
+            {
+                return $this->roles;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Summary

Two more authorization attributes building on the vocabulary added in #80.

### `#[RequiresRole(RoleInterface $role)]`
Enum-only, repeatable counterpart to `#[RequiresRoles]`. Each instance contributes one role; instances combine with the existing `#[RequiresRoles]` list under ANY-of (OR) semantics. Gates access — produces a 403 when unmet.

```php
#[RequiresRole(UserType::ADMIN)]
#[RequiresRole(UserType::SUPPORT)]   // ADMIN or SUPPORT
class UpdateSettingsController {}
```

### `#[AllowsRole(RoleInterface $role)]`
Repeatable, **purely additive** bypass. A user holding one of the allowed roles passes regardless of the route's `#[RequiresRole]`/`#[RequiresRoles]` and `#[RequiresPermission]` gates — the permission check (and the `AuthorizationServiceInterface` call) is skipped entirely for them.

```php
#[RequiresPermission(UserType::USER, Permission::EDIT)]
#[AllowsRole(UserType::ADMIN)]
// ADMIN          -> allowed (no permission check, no service call)
// USER w/ EDIT   -> allowed
// USER w/o EDIT  -> 403
// no user        -> 401
```

It **never restricts**: a handler carrying only `#[AllowsRole]` declares no gate and is effectively open. To *restrict* to a role, use `#[RequiresRole]`/`#[RequiresRoles]`. (This is the deliberate design choice that keeps it distinct from `RequiresRole` rather than a duplicate of it.)

### Implementation
`AccessControlEnforcer` computes the `AllowsRole` bypass up front — non-throwing on an absent or wrong-typed user, so the gates still raise the correct 401/403/RuntimeException when no role matches — and threads the bypass flag through both the role and permission gates.

## Test plan
- [x] `make style` (ECS) — clean
- [x] `make analyze` (PHPStan level 6) — clean
- [x] 75 tests / 151 assertions passing
- [x] Changed-line coverage: 100%
- New unit tests for both attributes, plus enforcer tests covering: RequiresRole OR-combination and 403, AllowsRole bypassing the permission gate (including with no service bound), AllowsRole bypassing the role gate, the permission gate still enforced for users without the allowed role, and AllowsRole-alone leaving the route open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `#[RequiresRole]` attribute as an enum-based, repeatable alternative to array-based role requirements with OR/ANY-of semantics across multiple declarations.
  * Added `#[AllowsRole]` attribute to grant access exceptions for specified roles, bypassing permission checks.

* **Documentation**
  * Updated architecture and README documentation to describe new role-based attributes and their access control semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->