### PR TITLE
feat: add pluggable RouteEnforcerInterface hook

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -25,6 +25,7 @@ use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
 use StrictlyPHP\Dolphin\Request\Method;
 use StrictlyPHP\Dolphin\Strategy\DolphinAppStrategy;
 use StrictlyPHP\Dolphin\Strategy\DtoMapper;
+use StrictlyPHP\Dolphin\Strategy\RouteEnforcerInterface;
 
 class App
 {
@@ -41,6 +42,7 @@ class App
      * @param array<int, string> $controllers
      * @param array<string, mixed> $containerDefinitions
      * @param array<int, class-string> $middlewares
+     * @param RouteEnforcerInterface[] $routeEnforcers
      */
     public static function build(
         array $controllers,
@@ -49,7 +51,8 @@ class App
         ?array $middlewares = [],
         ?bool $includeRoleCheck = true,
         ?MiddlewareInterface $throwableHandler = null,
-        ?\Closure $exceptionHandler = null
+        ?\Closure $exceptionHandler = null,
+        array $routeEnforcers = []
     ): self {
         if (empty($controllers)) {
             throw new \InvalidArgumentException('No controllers provided');
@@ -85,7 +88,8 @@ class App
             debugMode: $debugMode,
             includeRoleCheck: $includeRoleCheck,
             throwableHandler: $throwableHandler,
-            authorizationService: $authorizationService
+            authorizationService: $authorizationService,
+            routeEnforcers: $routeEnforcers
         );
         $strategy->setContainer($container);
         $router = new Router();

--- a/src/Strategy/AccessControlEnforcer.php
+++ b/src/Strategy/AccessControlEnforcer.php
@@ -20,7 +20,7 @@ use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
  * Enforces #[RequiresRoles], #[RequiresRole], #[RequiresPermission] and
  * #[AllowsRole] attributes declared on a matched route handler.
  */
-class AccessControlEnforcer
+class AccessControlEnforcer implements RouteEnforcerInterface
 {
     public function __construct(
         private ?AuthorizationServiceInterface $authorizationService = null
@@ -31,10 +31,14 @@ class AccessControlEnforcer
      * Runs role enforcement first, then permission enforcement. A user holding
      * an #[AllowsRole] role bypasses both gates. Returns the request with the
      * 'required_roles' and 'required_permissions' attributes set.
+     *
+     * @param array<string, string> $vars Unused by the built-in enforcer;
+     *                                    present to satisfy RouteEnforcerInterface.
      */
     public function enforce(
         ReflectionMethod|ReflectionFunction $ref,
-        ServerRequestInterface $request
+        ServerRequestInterface $request,
+        array $vars = []
     ): ServerRequestInterface {
         // #[AllowsRole] is purely additive: a user holding one of the allowed
         // roles passes regardless of the role/permission gates below.

--- a/src/Strategy/DolphinAppStrategy.php
+++ b/src/Strategy/DolphinAppStrategy.php
@@ -38,6 +38,16 @@ class DolphinAppStrategy extends JsonStrategy
          */
         private array $routeEnforcers = []
     ) {
+        foreach ($routeEnforcers as $index => $enforcer) {
+            if (! $enforcer instanceof RouteEnforcerInterface) {
+                throw new \InvalidArgumentException(sprintf(
+                    'routeEnforcers[%s] must implement %s',
+                    $index,
+                    RouteEnforcerInterface::class
+                ));
+            }
+        }
+
         parent::__construct($responseFactory, $jsonFlags);
         $this->accessControlEnforcer = new AccessControlEnforcer($authorizationService);
     }

--- a/src/Strategy/DolphinAppStrategy.php
+++ b/src/Strategy/DolphinAppStrategy.php
@@ -32,7 +32,11 @@ class DolphinAppStrategy extends JsonStrategy
         private ?bool $debugMode = false,
         private ?bool $includeRoleCheck = true,
         private ?MiddlewareInterface $throwableHandler = null,
-        ?AuthorizationServiceInterface $authorizationService = null
+        ?AuthorizationServiceInterface $authorizationService = null,
+        /**
+         * @var RouteEnforcerInterface[] $routeEnforcers
+         */
+        private array $routeEnforcers = []
     ) {
         parent::__construct($responseFactory, $jsonFlags);
         $this->accessControlEnforcer = new AccessControlEnforcer($authorizationService);
@@ -125,7 +129,11 @@ class DolphinAppStrategy extends JsonStrategy
         }
 
         if ($this->includeRoleCheck) {
-            $request = $this->accessControlEnforcer->enforce($ref, $request);
+            $request = $this->accessControlEnforcer->enforce($ref, $request, $route->getVars());
+        }
+
+        foreach ($this->routeEnforcers as $enforcer) {
+            $request = $enforcer->enforce($ref, $request, $route->getVars());
         }
 
         $parameters = $ref->getParameters();

--- a/src/Strategy/RouteEnforcerInterface.php
+++ b/src/Strategy/RouteEnforcerInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Dolphin\Strategy;
+
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionFunction;
+use ReflectionMethod;
+
+/**
+ * App-provided route enforcement that runs after Dolphin's built-in
+ * AccessControlEnforcer (which handles #[RequiresRoles], #[RequiresPermission],
+ * etc.) but before the controller body executes.
+ *
+ * Implementations reflect on the route handler for whatever class-level
+ * attributes they own, read state from the request and path vars, and throw
+ * `League\Route\Http\Exception\ForbiddenException` (or `UnauthorizedException`)
+ * on failure. Return the request — optionally with new attributes set — to
+ * pass control onward.
+ *
+ * Dolphin invokes each registered enforcer in registration order on every
+ * matched route. An enforcer with no work to do for the current route
+ * should return $request unchanged.
+ */
+interface RouteEnforcerInterface
+{
+    /**
+     * @param array<string, string> $vars Path variables extracted by League Route
+     *                                    (the same array passed to attribute-typed
+     *                                    `array $vars` controller params).
+     */
+    public function enforce(
+        ReflectionMethod|ReflectionFunction $ref,
+        ServerRequestInterface $request,
+        array $vars,
+    ): ServerRequestInterface;
+}

--- a/tests/Fixtures/TestWidgetController.php
+++ b/tests/Fixtures/TestWidgetController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Fixtures;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use StrictlyPHP\Dolphin\Attributes\RequiresRoles;
+use StrictlyPHP\Dolphin\Attributes\Route;
+use StrictlyPHP\Dolphin\Request\Method;
+use StrictlyPHP\Dolphin\Response\JsonResponse;
+
+#[Route(method: Method::GET, path: '/widgets/{id}')]
+#[RequiresRoles(roles: ['USER'])]
+class TestWidgetController
+{
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return new JsonResponse([
+            'response' => 'widget',
+            // Echo any attribute a route enforcer may have set, so tests can
+            // assert the enriched request reached the controller.
+            'enforced_by' => $request->getAttribute('enforced_by'),
+        ]);
+    }
+}

--- a/tests/Unit/Strategy/RouteEnforcerInterfaceTest.php
+++ b/tests/Unit/Strategy/RouteEnforcerInterfaceTest.php
@@ -130,6 +130,15 @@ class RouteEnforcerInterfaceTest extends TestCase
         $strategy->invokeRouteCallable($this->createRoute(), $request);
     }
 
+    public function testConstructorRejectsNonEnforcerEntries(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(RouteEnforcerInterface::class);
+
+        // @phpstan-ignore-next-line argument.type — intentionally invalid to assert the guard
+        $this->createStrategy([new \stdClass()]);
+    }
+
     /**
      * @param RouteEnforcerInterface[] $routeEnforcers
      */

--- a/tests/Unit/Strategy/RouteEnforcerInterfaceTest.php
+++ b/tests/Unit/Strategy/RouteEnforcerInterfaceTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Unit\Strategy;
+
+use League\Route\Http\Exception\ForbiddenException;
+use League\Route\Route;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionFunction;
+use ReflectionMethod;
+use Slim\Psr7\Factory\ResponseFactory;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use StrictlyPHP\Dolphin\Strategy\DolphinAppStrategy;
+use StrictlyPHP\Dolphin\Strategy\DtoMapper;
+use StrictlyPHP\Dolphin\Strategy\RouteEnforcerInterface;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestUserAdmin;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestUserRegular;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestWidgetController;
+
+class RouteEnforcerInterfaceTest extends TestCase
+{
+    public function testZeroEnforcersBehavesLikeToday(): void
+    {
+        $strategy = $this->createStrategy([]);
+
+        $response = $strategy->invokeRouteCallable($this->createRoute(), $this->createAuthenticatedRequest());
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('{"response":"widget","enforced_by":null}', (string) $response->getBody());
+    }
+
+    public function testSingleEnforcerIsCalledWithRefRequestAndVars(): void
+    {
+        $captured = [];
+
+        $enforcer = $this->createStub(RouteEnforcerInterface::class);
+        $enforcer->method('enforce')->willReturnCallback(
+            static function (
+                ReflectionMethod|ReflectionFunction $ref,
+                ServerRequestInterface $request,
+                array $vars
+            ) use (&$captured): ServerRequestInterface {
+                $captured = [
+                    'ref' => $ref,
+                    'vars' => $vars,
+                ];
+
+                return $request;
+            }
+        );
+
+        $strategy = $this->createStrategy([$enforcer]);
+        $route = $this->createRoute();
+        $route->setVars([
+            'id' => '42',
+        ]);
+
+        $strategy->invokeRouteCallable($route, $this->createAuthenticatedRequest());
+
+        $this->assertInstanceOf(ReflectionMethod::class, $captured['ref']);
+        $this->assertSame(TestWidgetController::class, $captured['ref']->getDeclaringClass()->getName());
+        $this->assertSame([
+            'id' => '42',
+        ], $captured['vars']);
+    }
+
+    public function testMultipleEnforcersRunInRegistrationOrderAndThreadTheRequest(): void
+    {
+        // Enforcer A appends 'a' to the attribute; B appends 'b'. The order of
+        // the final value proves A ran before B and that B saw A's request.
+        $append = static fn (string $tag): callable => static function (
+            ReflectionMethod|ReflectionFunction $ref,
+            ServerRequestInterface $request,
+            array $vars
+        ) use ($tag): ServerRequestInterface {
+            $current = (string) $request->getAttribute('enforced_by');
+
+            return $request->withAttribute('enforced_by', $current . $tag);
+        };
+
+        $enforcerA = $this->createStub(RouteEnforcerInterface::class);
+        $enforcerA->method('enforce')->willReturnCallback($append('a'));
+
+        $enforcerB = $this->createStub(RouteEnforcerInterface::class);
+        $enforcerB->method('enforce')->willReturnCallback($append('b'));
+
+        $strategy = $this->createStrategy([$enforcerA, $enforcerB]);
+
+        $response = $strategy->invokeRouteCallable($this->createRoute(), $this->createAuthenticatedRequest());
+
+        $this->assertSame('{"response":"widget","enforced_by":"ab"}', (string) $response->getBody());
+    }
+
+    public function testThrowingEnforcerHaltsChainBeforeSubsequentEnforcersAndController(): void
+    {
+        $thrower = $this->createStub(RouteEnforcerInterface::class);
+        $thrower->method('enforce')->willThrowException(new ForbiddenException('Policy violation'));
+
+        $shouldNotRun = $this->createStub(RouteEnforcerInterface::class);
+        $shouldNotRun->method('enforce')->willReturnCallback(
+            function (): ServerRequestInterface {
+                $this->fail('Enforcer after a throwing enforcer must not run');
+            }
+        );
+
+        $strategy = $this->createStrategy([$thrower, $shouldNotRun]);
+
+        $this->expectException(ForbiddenException::class);
+        $strategy->invokeRouteCallable($this->createRoute(), $this->createAuthenticatedRequest());
+    }
+
+    public function testBuiltInAccessControlRunsBeforeAdditionalEnforcers(): void
+    {
+        // The user lacks the required USER role, so AccessControlEnforcer must
+        // reject before the custom enforcer is ever consulted.
+        $shouldNotRun = $this->createStub(RouteEnforcerInterface::class);
+        $shouldNotRun->method('enforce')->willReturnCallback(
+            function (): ServerRequestInterface {
+                $this->fail('Custom enforcer must not run when the role gate fails');
+            }
+        );
+
+        $strategy = $this->createStrategy([$shouldNotRun]);
+        // TestUserAdmin holds ['ADMIN'] — no intersection with the required ['USER'].
+        $request = $this->createRequest()->withAttribute('user', new TestUserAdmin());
+
+        $this->expectException(ForbiddenException::class);
+        $strategy->invokeRouteCallable($this->createRoute(), $request);
+    }
+
+    /**
+     * @param RouteEnforcerInterface[] $routeEnforcers
+     */
+    private function createStrategy(array $routeEnforcers): DolphinAppStrategy
+    {
+        return new DolphinAppStrategy(
+            dtoMapper: new DtoMapper(),
+            responseFactory: new ResponseFactory(),
+            routeEnforcers: $routeEnforcers
+        );
+    }
+
+    private function createRoute(): Route
+    {
+        return new Route('GET', '/widgets/{id}', new TestWidgetController());
+    }
+
+    private function createRequest(): ServerRequestInterface
+    {
+        return (new ServerRequestFactory())->createServerRequest('GET', '/widgets/42');
+    }
+
+    private function createAuthenticatedRequest(): ServerRequestInterface
+    {
+        return $this->createRequest()->withAttribute('user', new TestUserRegular());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a domain-neutral extension point so consuming apps can run their own route-level policy (resource access, tenant membership, etc.) without subclassing `DolphinAppStrategy` or repeating checks inside every action body.

The existing `enforce()` shape is extracted into a public `RouteEnforcerInterface`. Dolphin owns the *lifecycle* (when enforcers run, what they receive); apps own the *policy* (which attributes they care about, what they throw). Dolphin imports no app types.

## What changed

- **New `src/Strategy/RouteEnforcerInterface.php`** — `enforce(ReflectionMethod|ReflectionFunction $ref, ServerRequestInterface $request, array $vars): ServerRequestInterface`.
- **`AccessControlEnforcer`** now `implements RouteEnforcerInterface`; `enforce()` gains a defaulted `$vars` param (unused by the built-in enforcer — backward compatible for existing callers).
- **`DolphinAppStrategy`** runs the built-in access control first, then loops registered enforcers in registration order, threading the request through each. New trailing `array $routeEnforcers = []` constructor param (after `authorizationService`, keeping arg order stable).
- **`App::build()`** passes a `routeEnforcers` array straight through to the strategy — explicit pass-through (like `middlewares`), no container-magic discovery.

## Tests

- `tests/Unit/Strategy/RouteEnforcerInterfaceTest.php` covers: zero enforcers behaves as today; single enforcer receives `(ref, request, vars)`; multiple run in order with the request threaded A→B; a throwing enforcer halts the chain (subsequent enforcer + controller never run); and built-in access control runs first (role failure short-circuits before custom enforcers).
- `tests/Fixtures/TestWidgetController.php` — neutral `USER`-gated `/widgets/{id}` fixture.

## Verification (in Docker)

- `phpunit tests/` → 80 tests, 159 assertions, OK
- `ecs` → clean
- `phpstan -l 6` → no errors

## Backward compatibility

Fully additive. Existing `AccessControlEnforcer` users, `App::build()` calls without `routeEnforcers`, and manually-constructed `DolphinAppStrategy` all behave exactly as before. Suggested release: minor (`3.5.0`).

## Out of scope

No new attribute classes, no DI-container conventions, no async/parallel enforcement — all left to consuming apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extensible route enforcer support so apps can chain custom request enforcement (runs after built-in access control, before controllers) and receive route variables.

* **Tests**
  * Added comprehensive tests covering enforcer chaining, ordering, error halting, role gating interaction, and constructor validation rejecting invalid enforcers.

* **Fixtures**
  * Added a test controller fixture to verify enforcement behavior end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->