### PR TITLE
fix(ci): pin symplify/easy-coding-standard to 13.1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "nikic/php-parser": "^5"
   },
   "require-dev": {
-    "symplify/easy-coding-standard": "^11.1 || ^12.0 || ^13.0",
+    "symplify/easy-coding-standard": "13.1.5",
     "phpstan/phpstan": "^1.8",
     "phpunit/phpunit": "^9.5",
     "phpstan/phpstan-phpunit": "^1.1",


### PR DESCRIPTION
## Problem

`make style` (the `Check Style` CI job) is failing on PRs with:

```
[ERROR] Expected an existing class name. Got:
"Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer"
... vendor/symplify/easy-coding-standard/config/set/common/spaces.php
```

The job dies during ECS bootstrap, before it inspects any source file — so this affects **every** open PR, not any one change.

## Root cause

`make install` does `rm -fr vendor composer.lock` and re-resolves from scratch. The dev constraint `"symplify/easy-coding-standard": "^11.1 || ^12.0 || ^13.0"` is wide enough that a fresh install now pulls a newer 13.x build whose bundled `SetList::SPACES` references `StandaloneLinePromotedPropertyFixer` — a class that build no longer ships. The known-good **13.1.5** (what local/lockfile installs resolve to) does not have this problem.

## Fix

Pin to the exact known-good version:

```diff
-    "symplify/easy-coding-standard": "^11.1 || ^12.0 || ^13.0",
+    "symplify/easy-coding-standard": "13.1.5",
```

A looser `~13.1.5`/`^13.1.5` would still let CI pull the broken newer patch, so an exact pin is the reliable lever given `make install` discards the lockfile.

Verified: fresh dependency resolution of the pinned constraint reports no conflicts, and `make style` passes with 13.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)