### PR TITLE
fix: harden JSON encoding so it never masks the real error

### DIFF
--- a/src/Json/SafeJsonEncoder.php
+++ b/src/Json/SafeJsonEncoder.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Dolphin\Json;
+
+/**
+ * Safe wrapper around json_encode() that is guaranteed never to return false.
+ *
+ * json_encode() returns false (it does not throw, unless JSON_THROW_ON_ERROR is
+ * set) when given malformed UTF-8, recursive structures, depth overflow, or
+ * NAN/INF. Passing that false straight to a PSR-7 Stream::write() raises a
+ * TypeError that masks the real, already-logged error. This helper degrades bad
+ * bytes to the Unicode replacement character and emits partial output on the
+ * remaining edge cases, so callers can always hand the result to write().
+ */
+final class SafeJsonEncoder
+{
+    public static function encode(mixed $data, int $flags = 0): string
+    {
+        $json = json_encode($data, $flags | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR);
+
+        return $json === false ? '' : $json;
+    }
+}

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -7,6 +7,7 @@ use Fig\Http\Message\StatusCodeInterface;
 use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Headers;
 use Slim\Psr7\Response;
+use StrictlyPHP\Dolphin\Json\SafeJsonEncoder;
 
 class JsonResponse extends Response
 {
@@ -15,8 +16,13 @@ class JsonResponse extends Response
      */
     public function __construct(\JsonSerializable|array $body, ?int $status = StatusCodeInterface::STATUS_OK)
     {
-        $encoded = json_encode($body);
-        if ($encoded === false) {
+        // Safe flags degrade malformed UTF-8 (e.g. legacy latin1 data) to the
+        // Unicode replacement character rather than failing the whole response.
+        // SafeJsonEncoder only returns '' for a genuinely un-encodable body, which
+        // we surface as a fail-fast exception that the hardened error handler can
+        // then render cleanly (never a write(false) TypeError).
+        $encoded = SafeJsonEncoder::encode($body);
+        if ($encoded === '') {
             throw new \RuntimeException('json_encode failed: ' . json_last_error_msg());
         }
 

--- a/src/Strategy/DolphinAppStrategy.php
+++ b/src/Strategy/DolphinAppStrategy.php
@@ -195,6 +195,12 @@ class DolphinAppStrategy extends JsonStrategy
 
         if ($this->isJsonSerializable($response)) {
             $body = SafeJsonEncoder::encode($response, $this->jsonFlags);
+            // '' means a genuinely un-encodable body survived the safe flags; fail
+            // fast so it flows into the hardened throwable handler rather than
+            // emitting a blank 200 that masks the failure.
+            if ($body === '') {
+                throw new \RuntimeException('json_encode failed: ' . json_last_error_msg());
+            }
             $response = $this->responseFactory->createResponse();
             $response->getBody()->write($body);
         }

--- a/src/Strategy/DolphinAppStrategy.php
+++ b/src/Strategy/DolphinAppStrategy.php
@@ -18,6 +18,7 @@ use ReflectionFunction;
 use ReflectionMethod;
 use ReflectionNamedType;
 use StrictlyPHP\Dolphin\Authorization\AuthorizationServiceInterface;
+use StrictlyPHP\Dolphin\Json\SafeJsonEncoder;
 use Throwable;
 
 class DolphinAppStrategy extends JsonStrategy
@@ -109,11 +110,21 @@ class DolphinAppStrategy extends JsonStrategy
                         $responseData['exception'] = [
                             'message' => $exception->getMessage(),
                             'request' => (string) $request->getBody(),
-                            'trace' => $exception->getTrace(),
+                            // getTraceAsString() is a plain string; getTrace() returns
+                            // frame arrays containing arbitrary call arguments (objects,
+                            // closures, binary blobs, circular refs) that can make
+                            // json_encode fail and mask this very error.
+                            'trace' => $exception->getTraceAsString(),
                         ];
                     }
 
-                    $response->getBody()->write(json_encode($responseData));
+                    // Guaranteed-string encode plus a hardcoded fallback so a secondary
+                    // encoding failure can never mask the primary, already-logged error.
+                    $body = SafeJsonEncoder::encode($responseData);
+                    if ($body === '') {
+                        $body = '{"statusCode":500,"reasonPhrase":"Internal Server Error"}';
+                    }
+                    $response->getBody()->write($body);
 
                     return $response
                         ->withAddedHeader('content-type', 'application/json')
@@ -183,7 +194,7 @@ class DolphinAppStrategy extends JsonStrategy
         $response = $callable(...$args);
 
         if ($this->isJsonSerializable($response)) {
-            $body = json_encode($response, $this->jsonFlags);
+            $body = SafeJsonEncoder::encode($response, $this->jsonFlags);
             $response = $this->responseFactory->createResponse();
             $response->getBody()->write($body);
         }
@@ -217,7 +228,7 @@ class DolphinAppStrategy extends JsonStrategy
                     );
                 }
 
-                $this->response->getBody()->write(json_encode([
+                $this->response->getBody()->write(SafeJsonEncoder::encode([
                     'statusCode' => $statusCode,
                     'reasonPhrase' => $message,
                 ]));

--- a/src/Strategy/DolphinAppStrategy.php
+++ b/src/Strategy/DolphinAppStrategy.php
@@ -122,7 +122,11 @@ class DolphinAppStrategy extends JsonStrategy
                     // encoding failure can never mask the primary, already-logged error.
                     $body = SafeJsonEncoder::encode($responseData);
                     if ($body === '') {
+                        // Unreachable in practice (the safe flags never yield ''); kept as
+                        // a last-resort guarantee that the handler itself cannot throw.
+                        // @codeCoverageIgnoreStart
                         $body = '{"statusCode":500,"reasonPhrase":"Internal Server Error"}';
+                        // @codeCoverageIgnoreEnd
                     }
                     $response->getBody()->write($body);
 
@@ -197,9 +201,11 @@ class DolphinAppStrategy extends JsonStrategy
             $body = SafeJsonEncoder::encode($response, $this->jsonFlags);
             // '' means a genuinely un-encodable body survived the safe flags; fail
             // fast so it flows into the hardened throwable handler rather than
-            // emitting a blank 200 that masks the failure.
+            // emitting a blank 200 that masks the failure. Unreachable in practice.
             if ($body === '') {
+                // @codeCoverageIgnoreStart
                 throw new \RuntimeException('json_encode failed: ' . json_last_error_msg());
+                // @codeCoverageIgnoreEnd
             }
             $response = $this->responseFactory->createResponse();
             $response->getBody()->write($body);

--- a/tests/Unit/Json/SafeJsonEncoderTest.php
+++ b/tests/Unit/Json/SafeJsonEncoderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Dolphin\Unit\Json;
+
+use PHPUnit\Framework\TestCase;
+use StrictlyPHP\Dolphin\Json\SafeJsonEncoder;
+
+class SafeJsonEncoderTest extends TestCase
+{
+    public function testItEncodesValidData(): void
+    {
+        $this->assertSame('{"a":1}', SafeJsonEncoder::encode([
+            'a' => 1,
+        ]));
+    }
+
+    public function testItSubstitutesInvalidUtf8(): void
+    {
+        $encoded = SafeJsonEncoder::encode([
+            'invalid' => "\xB1\x31",
+        ]);
+
+        $this->assertNotSame('', $encoded);
+        $this->assertSame([
+            'invalid' => "\u{FFFD}1",
+        ], json_decode($encoded, true));
+    }
+
+    public function testItReturnsStringForRecursiveStructure(): void
+    {
+        $data = [
+            'self' => null,
+        ];
+        $data['self'] = &$data;
+
+        $encoded = SafeJsonEncoder::encode($data);
+
+        // JSON_PARTIAL_OUTPUT_ON_ERROR keeps json_encode from returning false on a
+        // recursive structure; the helper must therefore always hand back a string.
+        $this->assertIsString($encoded);
+    }
+
+    public function testItReturnsStringForNanAndInf(): void
+    {
+        $encoded = SafeJsonEncoder::encode([
+            'nan' => NAN,
+            'inf' => INF,
+        ]);
+
+        $this->assertIsString($encoded);
+        $this->assertNotSame('', $encoded);
+    }
+
+    public function testItHonoursAdditionalFlags(): void
+    {
+        $encoded = SafeJsonEncoder::encode([
+            'url' => 'a/b',
+        ], JSON_UNESCAPED_SLASHES);
+
+        $this->assertSame('{"url":"a/b"}', $encoded);
+    }
+}

--- a/tests/Unit/Response/JsonResponseTest.php
+++ b/tests/Unit/Response/JsonResponseTest.php
@@ -9,13 +9,31 @@ use StrictlyPHP\Dolphin\Response\JsonResponse;
 
 class JsonResponseTest extends TestCase
 {
-    public function testItThrowsExceptionWhenJsonEncodeFails(): void
+    public function testItEncodesValidBody(): void
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('json_encode failed:');
+        $response = new JsonResponse([
+            'response' => 'ok',
+        ]);
 
-        new JsonResponse([
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('{"response":"ok"}', (string) $response->getBody());
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function testItDegradesMalformedUtf8InsteadOfThrowing(): void
+    {
+        $response = new JsonResponse([
             'invalid' => "\xB1\x31",
         ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = (string) $response->getBody();
+        // The malformed byte is substituted with the Unicode replacement character
+        // and the response is still valid JSON, rather than a hard failure.
+        $this->assertIsArray(json_decode($body, true));
+        $this->assertSame([
+            'invalid' => "\u{FFFD}1",
+        ], json_decode($body, true));
     }
 }

--- a/tests/Unit/Strategy/DolphinAppStrategyTest.php
+++ b/tests/Unit/Strategy/DolphinAppStrategyTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Slim\Psr7\Factory\ResponseFactory;
 use Slim\Psr7\Factory\ServerRequestFactory;
 use StrictlyPHP\Dolphin\Authentication\AuthenticatedUserInterface;
@@ -21,6 +22,7 @@ use StrictlyPHP\Dolphin\Response\JsonResponse;
 use StrictlyPHP\Dolphin\Strategy\DolphinAppStrategy;
 use StrictlyPHP\Dolphin\Strategy\DtoMapper;
 use StrictlyPHP\Tests\Dolphin\Fixtures\Authorization\TestPermission;
+use StrictlyPHP\Tests\Dolphin\Fixtures\TestLogger;
 use StrictlyPHP\Tests\Dolphin\Fixtures\TestRequiresAnyPermissionController;
 use StrictlyPHP\Tests\Dolphin\Fixtures\TestRequiresPermissionController;
 use StrictlyPHP\Tests\Dolphin\Fixtures\TestUserAdmin;
@@ -165,6 +167,133 @@ class DolphinAppStrategyTest extends TestCase
 
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('{"response":"ok"}', (string) $response->getBody());
+    }
+
+    public function testSuccessPathDegradesMalformedUtf8InsteadOf500(): void
+    {
+        $controller = new class() {
+            /**
+             * @return array<string, string>
+             */
+            public function __invoke(ServerRequestInterface $request): array
+            {
+                return [
+                    'response' => "bad\xB1byte",
+                ];
+            }
+        };
+
+        $strategy = $this->createStrategy(null);
+        $route = new Route('GET', '/legacy', $controller);
+
+        $response = $strategy->invokeRouteCallable($route, $this->createRequest());
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $decoded = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($decoded);
+        $this->assertSame("bad\u{FFFD}byte", $decoded['response']);
+    }
+
+    public function testErrorHandlerNeverMasksRealErrorWithUnencodablePayload(): void
+    {
+        $logger = new TestLogger();
+        $strategy = new DolphinAppStrategy(
+            dtoMapper: new DtoMapper(),
+            responseFactory: new ResponseFactory(),
+            logger: $logger,
+            debugMode: true,
+        );
+
+        // A message containing malformed UTF-8 would make json_encode() return false
+        // on the old code path, producing a write(false) TypeError that masks this
+        // very exception.
+        $realException = new \RuntimeException("missing table \xB1 recruiter_jobs");
+
+        $handler = new class($realException) implements RequestHandlerInterface {
+            public function __construct(
+                private \Throwable $exception
+            ) {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                throw $this->exception;
+            }
+        };
+
+        $response = $strategy->getThrowableHandler()->process($this->createRequest(), $handler);
+
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertSame('application/json', $response->getHeaderLine('content-type'));
+
+        $decoded = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($decoded);
+        $this->assertSame(500, $decoded['statusCode']);
+        // The real, logged error survives into the response (bad byte substituted).
+        $this->assertStringContainsString('missing table', $decoded['exception']['message']);
+        $this->assertStringContainsString('recruiter_jobs', $decoded['exception']['message']);
+        // The trace is a plain string, not an array of frame args.
+        $this->assertIsString($decoded['exception']['trace']);
+
+        $this->assertSame('critical', $logger->getLogs()[0]['level']);
+    }
+
+    public function testErrorHandlerEncodesTraceThroughClosureAsString(): void
+    {
+        $strategy = new DolphinAppStrategy(
+            dtoMapper: new DtoMapper(),
+            responseFactory: new ResponseFactory(),
+            debugMode: true,
+        );
+
+        // Build an exception whose stack trace passes an object and a closure as
+        // call arguments — getTrace() frame args that are not json-encodable.
+        $handler = new class() implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $thrower = static function (object $obj, \Closure $fn): void {
+                    throw new \RuntimeException('boom through closure');
+                };
+
+                $thrower(new \stdClass(), static fn (): bool => true);
+            }
+        };
+
+        $response = $strategy->getThrowableHandler()->process($this->createRequest(), $handler);
+
+        $this->assertSame(500, $response->getStatusCode());
+
+        $decoded = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($decoded);
+        $this->assertSame('boom through closure', $decoded['exception']['message']);
+        $this->assertIsString($decoded['exception']['trace']);
+    }
+
+    public function testNonDebugErrorHandlerReturnsCleanJsonWithoutTrace(): void
+    {
+        $strategy = new DolphinAppStrategy(
+            dtoMapper: new DtoMapper(),
+            responseFactory: new ResponseFactory(),
+            debugMode: false,
+        );
+
+        $handler = new class() implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                throw new \RuntimeException('something broke');
+            }
+        };
+
+        $response = $strategy->getThrowableHandler()->process($this->createRequest(), $handler);
+
+        $this->assertSame(500, $response->getStatusCode());
+
+        $decoded = json_decode((string) $response->getBody(), true);
+        $this->assertSame([
+            'statusCode' => 500,
+            'reasonPhrase' => 'Internal Server Error',
+        ], $decoded);
     }
 
     private function createStrategy(?AuthorizationServiceInterface $authorizationService): DolphinAppStrategy


### PR DESCRIPTION
## Problem

On staging, a request returned a 500 whose body was:

```json
{ "error": "Internal Server Error",
  "message": "fwrite(): Argument #2 ($data) must be of type string, false given",
  "trace": "#0 ... Slim\\Psr7\\Stream->write(false) ... DolphinAppStrategy.php(116) ..." }
```

The **real** cause was unrelated (a missing DB table → a DBAL exception). Dolphin's own error handler couldn't `json_encode` its error payload, so `json_encode` returned `false`, `Stream->write(false)` threw a `TypeError`, and **that** TypeError replaced the genuine, already-logged error. Hours were lost chasing the `fwrite` message.

## Root cause

`json_encode()` returns `false` (it does **not** throw, absent `JSON_THROW_ON_ERROR`) on malformed UTF‑8, recursive structures, depth overflow, or NAN/INF. Dolphin passed those results straight to `Stream::write()` without a false-check or defensive flags. The dominant trigger: the debug error handler embedded `$exception->getTrace()` — frame arrays of arbitrary call args (objects, closures, binary blobs, circular refs) — which `json_encode` cannot encode.

## Changes

- **New `SafeJsonEncoder::encode()`** — single helper that OR's in `JSON_INVALID_UTF8_SUBSTITUTE` + `JSON_PARTIAL_OUTPUT_ON_ERROR` and is guaranteed never to return `false` to a stream write. (Standalone class rather than a private method because the anonymous-class middlewares can't reach an enclosing class's private members.)
- **Error handler** — uses `getTraceAsString()` (a plain string; also no longer leaks call args), encodes via the helper, and falls back to a hardcoded literal so a secondary encode failure can never mask the primary error.
- **Success path** and **non-debug error path** routed through the helper too.
- **`JsonResponse`** uses the helper, degrading malformed UTF‑8 instead of a hard 500; it still fail-fasts only on a genuinely un-encodable body, which the hardened handler now renders cleanly.

## Tests

`make style`, `make analyze` (PHPStan L6), and the full suite (91 tests) pass. New/updated coverage:

- `SafeJsonEncoderTest` — invalid-UTF‑8 substitution, recursive/NAN/INF inputs, extra flags.
- `JsonResponseTest` — malformed UTF‑8 now degrades to valid JSON (old "throws" expectation reflected the bug).
- `DolphinAppStrategyTest` — error handler given an un-encodable message and a trace through a closure/object asserts clean JSON, a string trace, and no `TypeError`; success path degrades malformed UTF‑8 (200, not 500); non-debug path returns clean JSON without a trace.

## Acceptance criteria

- [x] Malformed UTF‑8 in a response → valid JSON (bad bytes substituted), correct status — not a 500.
- [x] On a thrown action the response (debug & non-debug) carries the real exception message/status; the handler can never emit a `fwrite(): ... false given` TypeError.
- [x] Debug payload carries the trace as a **string** (`getTraceAsString()`).
- [x] No code path passes a possibly-`false` `json_encode()` result to `Stream::write()`.

## Consumer note

Library fix. Once released, bump `strictlyphp/dolphin` in the Auxeris services and worker. Independent of — but surfaced by — the SCRUM-465 / `recruiter_jobs` work; the staging incident itself was already fixed by creating the missing table. This PR removes the **masking** so the next such error is diagnosable in minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON responses now use a safer encoding approach that replaces malformed UTF-8 instead of failing.
  * Error responses remain JSON-formatted reliably, including debug details when applicable.
* **Bug Fixes**
  * Prevented malformed or problematic payloads (including recursive structures and numeric edge cases) from causing server errors or blank bodies.
  * Improved debug error handling so stack traces are encoded consistently as strings.
* **Tests**
  * Added unit tests covering safe encoding, malformed UTF-8 degradation, and response/error behavior across debug and non-debug modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->