### PR TITLE
style: satisfy ECS 13.2 fixer rules

### DIFF
--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace StrictlyPHP\Dolphin\Response;
 
 use Fig\Http\Message\StatusCodeInterface;

--- a/src/Strategy/AccessControlEnforcer.php
+++ b/src/Strategy/AccessControlEnforcer.php
@@ -93,7 +93,8 @@ class AccessControlEnforcer implements RouteEnforcerInterface
 
         // Class-level attributes (function handlers have no declaring class)
         if ($ref instanceof ReflectionMethod) {
-            $permissionAttrs = $ref->getDeclaringClass()->getAttributes(RequiresPermission::class);
+            $permissionAttrs = $ref->getDeclaringClass()
+                ->getAttributes(RequiresPermission::class);
             foreach ($permissionAttrs as $permissionAttr) {
                 $requiredPermissions[] = $permissionAttr->newInstance();
             }

--- a/src/Strategy/DolphinAppStrategy.php
+++ b/src/Strategy/DolphinAppStrategy.php
@@ -35,7 +35,7 @@ class DolphinAppStrategy extends JsonStrategy
         private ?MiddlewareInterface $throwableHandler = null,
         ?AuthorizationServiceInterface $authorizationService = null,
         /**
-         * @var RouteEnforcerInterface[] $routeEnforcers
+         * @var RouteEnforcerInterface[]
          */
         private array $routeEnforcers = []
     ) {
@@ -128,7 +128,8 @@ class DolphinAppStrategy extends JsonStrategy
                         $body = '{"statusCode":500,"reasonPhrase":"Internal Server Error"}';
                         // @codeCoverageIgnoreEnd
                     }
-                    $response->getBody()->write($body);
+                    $response->getBody()
+                        ->write($body);
 
                     return $response
                         ->withAddedHeader('content-type', 'application/json')
@@ -183,7 +184,8 @@ class DolphinAppStrategy extends JsonStrategy
             }
 
             if (class_exists($typeName)) {
-                $body = $request->getBody()->getContents();
+                $body = $request->getBody()
+                    ->getContents();
                 $data = json_decode($body, true);
 
                 if (! is_array($data)) {
@@ -208,7 +210,8 @@ class DolphinAppStrategy extends JsonStrategy
                 // @codeCoverageIgnoreEnd
             }
             $response = $this->responseFactory->createResponse();
-            $response->getBody()->write($body);
+            $response->getBody()
+                ->write($body);
         }
 
         return $this->decorateResponse($response);
@@ -240,10 +243,11 @@ class DolphinAppStrategy extends JsonStrategy
                     );
                 }
 
-                $this->response->getBody()->write(SafeJsonEncoder::encode([
-                    'statusCode' => $statusCode,
-                    'reasonPhrase' => $message,
-                ]));
+                $this->response->getBody()
+                    ->write(SafeJsonEncoder::encode([
+                        'statusCode' => $statusCode,
+                        'reasonPhrase' => $message,
+                    ]));
 
                 $response = $this->response->withAddedHeader('content-type', 'application/json');
                 return $response->withStatus($statusCode);

--- a/src/Strategy/DtoMapper.php
+++ b/src/Strategy/DtoMapper.php
@@ -102,7 +102,8 @@ class DtoMapper
 
     private function resolveArrayDocblockType(ReflectionParameter $param): string
     {
-        $rawDoc = $param->getDeclaringFunction()->getDocComment() ?: '';
+        $rawDoc = $param->getDeclaringFunction()
+            ->getDocComment() ?: '';
         $paramName = $param->getName();
 
         // collapse whitespace
@@ -135,7 +136,8 @@ class DtoMapper
 
     private function resolveClassNameFromImports(ReflectionParameter $param, string $shortName): string
     {
-        $dtoClass = $param->getDeclaringClass()->getName();
+        $dtoClass = $param->getDeclaringClass()
+            ->getName();
         $importMap = $this->getImportMapForDto($dtoClass);
 
         // If the short name matches an import alias, return that
@@ -144,7 +146,8 @@ class DtoMapper
         }
 
         // Otherwise fallback to namespace of the DTO
-        $dtoNamespace = $param->getDeclaringClass()->getNamespaceName();
+        $dtoNamespace = $param->getDeclaringClass()
+            ->getNamespaceName();
         $candidate = $dtoNamespace . '\\' . $shortName;
 
         if (class_exists($candidate)) {
@@ -229,7 +232,8 @@ class DtoMapper
 
     private function arrayAllowsNullElements(ReflectionParameter $param): bool
     {
-        $doc = $param->getDeclaringFunction()->getDocComment() ?: '';
+        $doc = $param->getDeclaringFunction()
+            ->getDocComment() ?: '';
         return preg_match('/array<\w+,\s*\?/', $doc) === 1;
     }
 
@@ -360,7 +364,7 @@ class DtoMapper
                 if (class_exists($className)) {
                     try {
                         return (new ReflectionClass($className))->newInstanceArgs([$raw]);
-                    } catch (\ReflectionException | \TypeError | \ArgumentCountError) {
+                    } catch (\ReflectionException|\TypeError|\ArgumentCountError) {
                         continue;
                     }
                 }

--- a/tests/Fixtures/TestAttributeController.php
+++ b/tests/Fixtures/TestAttributeController.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace StrictlyPHP\Tests\Dolphin\Fixtures;
 
 use League\Route\Http\Exception\UnauthorizedException;

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace StrictlyPHP\Tests\Dolphin\Fixtures;
 
 use Psr\Http\Message\ResponseInterface;
@@ -12,7 +13,8 @@ class TestController
     public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
         return new JsonResponse([
-            'requestBody' => $request->getBody()->getContents(),
+            'requestBody' => $request->getBody()
+                ->getContents(),
         ]);
     }
 }

--- a/tests/Fixtures/TestNamedAttributeController.php
+++ b/tests/Fixtures/TestNamedAttributeController.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace StrictlyPHP\Tests\Dolphin\Fixtures;
 
 use League\Route\Http\Exception\UnauthorizedException;

--- a/tests/Fixtures/TestRequiresRoleController.php
+++ b/tests/Fixtures/TestRequiresRoleController.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace StrictlyPHP\Tests\Dolphin\Fixtures;
 
 use League\Route\Http\Exception\UnauthorizedException;

--- a/tests/Integration/AppAttributeTest.php
+++ b/tests/Integration/AppAttributeTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace StrictlyPHP\Tests\Dolphin\Integration;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Integration/AppNamedAttributeTest.php
+++ b/tests/Integration/AppNamedAttributeTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace StrictlyPHP\Tests\Dolphin\Integration;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Integration/AppPermissionTest.php
+++ b/tests/Integration/AppPermissionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace StrictlyPHP\Tests\Dolphin\Integration;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Integration/AppRoleTest.php
+++ b/tests/Integration/AppRoleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace StrictlyPHP\Tests\Dolphin\Integration;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Integration/AppTest.php
+++ b/tests/Integration/AppTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace StrictlyPHP\Tests\Dolphin\Integration;
 
 use DI\ContainerBuilder;

--- a/tests/Unit/Strategy/AccessControlEnforcerTest.php
+++ b/tests/Unit/Strategy/AccessControlEnforcerTest.php
@@ -41,7 +41,8 @@ class AccessControlEnforcerTest extends TestCase
     public function testItSetsRequiredPermissionsAttributeOnTheRequest(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturn(true);
+        $authorizationService->method('isAllowed')
+            ->willReturn(true);
 
         $enforcer = new AccessControlEnforcer($authorizationService);
         $ref = new ReflectionMethod(TestRequiresPermissionController::class, '__invoke');
@@ -61,7 +62,8 @@ class AccessControlEnforcerTest extends TestCase
     public function testItSetsAllRepeatedPermissionsOnTheRequest(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturn(true);
+        $authorizationService->method('isAllowed')
+            ->willReturn(true);
 
         $enforcer = new AccessControlEnforcer($authorizationService);
         $ref = new ReflectionMethod(TestRequiresAnyPermissionController::class, '__invoke');
@@ -131,7 +133,8 @@ class AccessControlEnforcerTest extends TestCase
     public function testAllowsRoleBypassesPermissionGateWithoutCallingService(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturn(false);
+        $authorizationService->method('isAllowed')
+            ->willReturn(false);
 
         $enforcer = new AccessControlEnforcer($authorizationService);
         $ref = new ReflectionMethod(TestAllowsRolePermissionController::class, '__invoke');
@@ -158,7 +161,8 @@ class AccessControlEnforcerTest extends TestCase
     public function testPermissionGateStillEnforcedForUsersWithoutTheAllowedRole(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturn(true);
+        $authorizationService->method('isAllowed')
+            ->willReturn(true);
 
         $enforcer = new AccessControlEnforcer($authorizationService);
         $ref = new ReflectionMethod(TestAllowsRolePermissionController::class, '__invoke');
@@ -173,7 +177,8 @@ class AccessControlEnforcerTest extends TestCase
     public function testPermissionGateDeniesUserWithoutAllowedRoleOrPermission(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturn(false);
+        $authorizationService->method('isAllowed')
+            ->willReturn(false);
 
         $enforcer = new AccessControlEnforcer($authorizationService);
         $ref = new ReflectionMethod(TestAllowsRolePermissionController::class, '__invoke');

--- a/tests/Unit/Strategy/DolphinAppStrategyTest.php
+++ b/tests/Unit/Strategy/DolphinAppStrategyTest.php
@@ -58,7 +58,8 @@ class DolphinAppStrategyTest extends TestCase
     public function testRequiresPermissionAllowsWhenAuthorizationServiceAllows(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturn(true);
+        $authorizationService->method('isAllowed')
+            ->willReturn(true);
 
         $strategy = $this->createStrategy($authorizationService);
         $route = new Route('POST', '/permission', new TestRequiresPermissionController());
@@ -72,7 +73,8 @@ class DolphinAppStrategyTest extends TestCase
     public function testRequiresPermissionThrows403WhenAuthorizationServiceDenies(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturn(false);
+        $authorizationService->method('isAllowed')
+            ->willReturn(false);
 
         $strategy = $this->createStrategy($authorizationService);
         $route = new Route('POST', '/permission', new TestRequiresPermissionController());
@@ -84,13 +86,14 @@ class DolphinAppStrategyTest extends TestCase
     public function testRepeatedRequiresPermissionAllowsWhenAnyPermissionAllows(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturnCallback(
-            static fn (
-                AuthenticatedUserInterface $user,
-                RoleInterface $userKind,
-                PermissionInterface $permission
-            ): bool => $permission === TestPermission::CREATE_USER
-        );
+        $authorizationService->method('isAllowed')
+            ->willReturnCallback(
+                static fn (
+                    AuthenticatedUserInterface $user,
+                    RoleInterface $userKind,
+                    PermissionInterface $permission
+                ): bool => $permission === TestPermission::CREATE_USER
+            );
 
         $strategy = $this->createStrategy($authorizationService);
         // Declares DELETE_USER (denied) and CREATE_USER (allowed) — ANY-of passes
@@ -104,7 +107,8 @@ class DolphinAppStrategyTest extends TestCase
     public function testRepeatedRequiresPermissionThrows403WhenAllPermissionsDeny(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturn(false);
+        $authorizationService->method('isAllowed')
+            ->willReturn(false);
 
         $strategy = $this->createStrategy($authorizationService);
         $route = new Route('POST', '/any-permission', new TestRequiresAnyPermissionController());
@@ -126,7 +130,8 @@ class DolphinAppStrategyTest extends TestCase
     public function testRequiresPermissionThrows401WhenNoUserOnRequest(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturn(true);
+        $authorizationService->method('isAllowed')
+            ->willReturn(true);
 
         $strategy = $this->createStrategy($authorizationService);
         $route = new Route('POST', '/permission', new TestRequiresPermissionController());
@@ -138,11 +143,13 @@ class DolphinAppStrategyTest extends TestCase
     public function testRequiresPermissionThrowsRuntimeExceptionWhenUserIsWrongType(): void
     {
         $authorizationService = $this->createStub(AuthorizationServiceInterface::class);
-        $authorizationService->method('isAllowed')->willReturn(true);
+        $authorizationService->method('isAllowed')
+            ->willReturn(true);
 
         $strategy = $this->createStrategy($authorizationService);
         $route = new Route('POST', '/permission', new TestRequiresPermissionController());
-        $request = $this->createRequest()->withAttribute('user', new \stdClass());
+        $request = $this->createRequest()
+            ->withAttribute('user', new \stdClass());
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(AuthenticatedUserInterface::class);
@@ -222,7 +229,8 @@ class DolphinAppStrategyTest extends TestCase
             }
         };
 
-        $response = $strategy->getThrowableHandler()->process($this->createRequest(), $handler);
+        $response = $strategy->getThrowableHandler()
+            ->process($this->createRequest(), $handler);
 
         $this->assertSame(500, $response->getStatusCode());
         $this->assertSame('application/json', $response->getHeaderLine('content-type'));
@@ -260,7 +268,8 @@ class DolphinAppStrategyTest extends TestCase
             }
         };
 
-        $response = $strategy->getThrowableHandler()->process($this->createRequest(), $handler);
+        $response = $strategy->getThrowableHandler()
+            ->process($this->createRequest(), $handler);
 
         $this->assertSame(500, $response->getStatusCode());
 
@@ -285,7 +294,8 @@ class DolphinAppStrategyTest extends TestCase
             }
         };
 
-        $response = $strategy->getThrowableHandler()->process($this->createRequest(), $handler);
+        $response = $strategy->getThrowableHandler()
+            ->process($this->createRequest(), $handler);
 
         $this->assertSame(500, $response->getStatusCode());
 
@@ -312,6 +322,7 @@ class DolphinAppStrategyTest extends TestCase
 
     private function createAuthenticatedRequest(): ServerRequestInterface
     {
-        return $this->createRequest()->withAttribute('user', new TestUserAdmin());
+        return $this->createRequest()
+            ->withAttribute('user', new TestUserAdmin());
     }
 }

--- a/tests/Unit/Strategy/RouteEnforcerInterfaceTest.php
+++ b/tests/Unit/Strategy/RouteEnforcerInterfaceTest.php
@@ -36,20 +36,21 @@ class RouteEnforcerInterfaceTest extends TestCase
         $captured = [];
 
         $enforcer = $this->createStub(RouteEnforcerInterface::class);
-        $enforcer->method('enforce')->willReturnCallback(
-            static function (
-                ReflectionMethod|ReflectionFunction $ref,
-                ServerRequestInterface $request,
-                array $vars
-            ) use (&$captured): ServerRequestInterface {
-                $captured = [
-                    'ref' => $ref,
-                    'vars' => $vars,
-                ];
+        $enforcer->method('enforce')
+            ->willReturnCallback(
+                static function (
+                    ReflectionMethod|ReflectionFunction $ref,
+                    ServerRequestInterface $request,
+                    array $vars
+                ) use (&$captured): ServerRequestInterface {
+                    $captured = [
+                        'ref' => $ref,
+                        'vars' => $vars,
+                    ];
 
-                return $request;
-            }
-        );
+                    return $request;
+                }
+            );
 
         $strategy = $this->createStrategy([$enforcer]);
         $route = $this->createRoute();
@@ -81,10 +82,12 @@ class RouteEnforcerInterfaceTest extends TestCase
         };
 
         $enforcerA = $this->createStub(RouteEnforcerInterface::class);
-        $enforcerA->method('enforce')->willReturnCallback($append('a'));
+        $enforcerA->method('enforce')
+            ->willReturnCallback($append('a'));
 
         $enforcerB = $this->createStub(RouteEnforcerInterface::class);
-        $enforcerB->method('enforce')->willReturnCallback($append('b'));
+        $enforcerB->method('enforce')
+            ->willReturnCallback($append('b'));
 
         $strategy = $this->createStrategy([$enforcerA, $enforcerB]);
 
@@ -96,14 +99,16 @@ class RouteEnforcerInterfaceTest extends TestCase
     public function testThrowingEnforcerHaltsChainBeforeSubsequentEnforcersAndController(): void
     {
         $thrower = $this->createStub(RouteEnforcerInterface::class);
-        $thrower->method('enforce')->willThrowException(new ForbiddenException('Policy violation'));
+        $thrower->method('enforce')
+            ->willThrowException(new ForbiddenException('Policy violation'));
 
         $shouldNotRun = $this->createStub(RouteEnforcerInterface::class);
-        $shouldNotRun->method('enforce')->willReturnCallback(
-            function (): ServerRequestInterface {
-                $this->fail('Enforcer after a throwing enforcer must not run');
-            }
-        );
+        $shouldNotRun->method('enforce')
+            ->willReturnCallback(
+                function (): ServerRequestInterface {
+                    $this->fail('Enforcer after a throwing enforcer must not run');
+                }
+            );
 
         $strategy = $this->createStrategy([$thrower, $shouldNotRun]);
 
@@ -116,15 +121,17 @@ class RouteEnforcerInterfaceTest extends TestCase
         // The user lacks the required USER role, so AccessControlEnforcer must
         // reject before the custom enforcer is ever consulted.
         $shouldNotRun = $this->createStub(RouteEnforcerInterface::class);
-        $shouldNotRun->method('enforce')->willReturnCallback(
-            function (): ServerRequestInterface {
-                $this->fail('Custom enforcer must not run when the role gate fails');
-            }
-        );
+        $shouldNotRun->method('enforce')
+            ->willReturnCallback(
+                function (): ServerRequestInterface {
+                    $this->fail('Custom enforcer must not run when the role gate fails');
+                }
+            );
 
         $strategy = $this->createStrategy([$shouldNotRun]);
         // TestUserAdmin holds ['ADMIN'] — no intersection with the required ['USER'].
-        $request = $this->createRequest()->withAttribute('user', new TestUserAdmin());
+        $request = $this->createRequest()
+            ->withAttribute('user', new TestUserAdmin());
 
         $this->expectException(ForbiddenException::class);
         $strategy->invokeRouteCallable($this->createRoute(), $request);
@@ -163,6 +170,7 @@ class RouteEnforcerInterfaceTest extends TestCase
 
     private function createAuthenticatedRequest(): ServerRequestInterface
     {
-        return $this->createRequest()->withAttribute('user', new TestUserRegular());
+        return $this->createRequest()
+            ->withAttribute('user', new TestUserRegular());
     }
 }


### PR DESCRIPTION
Unblocks #90 (`symplify/easy-coding-standard` 13.1.5 → 13.2.17), which currently fails `make style` — the first CI step, so `analyze` and `check-coverage` never ran there. The bump itself touches only `composer.json`; the 16 flagged files are all pre-existing code that the newer fixer rules no longer accept.

Fixers that fired:

| Count | Fixer |
|---|---|
| 10 | `BlankLineAfterStrictTypesFixer` |
| 7 | `MethodChainingNewlineFixer` + `MethodChainingIndentationFixer` |
| 3 | `UnaryOperatorSpacesFixer` / `NotOperatorWithSuccessorSpaceFixer` |
| 2 | `MethodArgumentSpaceFixer` |
| 1 each | `RemovePropertyVariableNameDescriptionFixer`, `TypesSpacesFixer`, `StatementIndentationFixer`, `ArrayIndentationFixer` |

Produced by `ecs --fix` under 13.2.17. Whitespace and docblock only — no behaviour change.

`composer.json` deliberately keeps the `13.1.5` pin so this can land on its own; the bump stays with #90. Verified clean under **both** versions locally, plus `phpstan -l 6` (no errors), 91 tests / 189 assertions passing, and the patch-coverage gate at 86%.

Once this is merged, `@dependabot rebase` on #90 should turn it green.

Note for a follow-up: 13.2.x also warns that `ecs.php`’s `return function (ECSConfig $ecsConfig)` format is deprecated in favour of `ECSConfig::configure()`. Warning only today, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized formatting and spacing across response handling, access control, routing, and data-mapping code.
  - Improved readability of chained method calls, exception handling, and documentation.

- **Tests**
  - Aligned test fixtures and integration tests with consistent file formatting.
  - Improved readability of mocked calls and fluent test setup expressions without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->