### PR TITLE
chore: prepare release 3.5.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
-Changelog for version 3.5.0
+Changelog for version 3.5.1
 
-- feat: validate routeEnforcers entries in DolphinAppStrategy constructor (Ken Lalobo)
-- feat: add pluggable RouteEnforcerInterface hook (Ken Lalobo)
-- fix(ci): pin symplify/easy-coding-standard to 13.1.5 (Ken Lalobo)
+- deps(deps-dev): update symplify/easy-coding-standard requirement (dependabot[bot])
+- style: satisfy ECS 13.2 fixer rules (Ken Lalobo)
+- test: exclude unreachable encoder-failure guards from coverage (Ken Lalobo)
+- fix: fail fast on un-encodable route response instead of blank 200 (Ken Lalobo)
+- fix: harden JSON encoding so it never masks the real error (Ken Lalobo)
+- chore(deps): bump actions/checkout from 6 to 7 (dependabot[bot])

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "strictlyphp/dolphpin",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "type": "library",
   "license": "MIT",
   "autoload": {


### PR DESCRIPTION
Patch release — corrective changes only, no signature changes to existing public API.

- `fix: harden JSON encoding so it never masks the real error` (#88)
- `fix: fail fast on un-encodable route response instead of blank 200` (#88)
- `test: exclude unreachable encoder-failure guards from coverage` (#88)
- `style: satisfy ECS 13.2 fixer rules` (#91)
- `deps(deps-dev): update symplify/easy-coding-standard 13.1.5 → 13.2.17` (#90)
- `chore(deps): bump actions/checkout from 6 to 7` (#87)

Generated by `./build/create-release.sh 3.5.1` — `changelog.txt` regenerated from `3.5.0..HEAD` and `composer.json` bumped to `3.5.1`. All four gates passed locally (`make install`, `analyze`, `style`, `check-coverage`).

⚠️ Merge with a **merge commit**, not squash — `tag-and-release-on-merge-v1.yml` greps `release/x.y.z` out of the merge commit message to derive the tag, and a squash message would not contain it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)